### PR TITLE
15-16 suite cleanup

### DIFF
--- a/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_aggregate.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_aggregate.test.ts
@@ -18,8 +18,8 @@ it('latest-postgres-create_aggregate', async () => {
   "latest/postgres/create_aggregate-12.sql",
   "latest/postgres/create_aggregate-13.sql",
   "latest/postgres/create_aggregate-14.sql",
-  "latest/postgres/create_aggregate-15.sql",
-  "latest/postgres/create_aggregate-16.sql",
+  // "latest/postgres/create_aggregate-15.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "latest/postgres/create_aggregate-16.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "latest/postgres/create_aggregate-17.sql",
   "latest/postgres/create_aggregate-18.sql",
   "latest/postgres/create_aggregate-19.sql",
@@ -51,7 +51,7 @@ it('latest-postgres-create_aggregate', async () => {
   "latest/postgres/create_aggregate-45.sql",
   "latest/postgres/create_aggregate-46.sql",
   "latest/postgres/create_aggregate-47.sql",
-  "latest/postgres/create_aggregate-48.sql",
+  // "latest/postgres/create_aggregate-48.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "latest/postgres/create_aggregate-49.sql",
   "latest/postgres/create_aggregate-50.sql",
   "latest/postgres/create_aggregate-51.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_am.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_am.test.ts
@@ -65,10 +65,10 @@ it('latest-postgres-create_am', async () => {
   "latest/postgres/create_am-59.sql",
   "latest/postgres/create_am-60.sql",
   "latest/postgres/create_am-61.sql",
-  "latest/postgres/create_am-62.sql",
+  // "latest/postgres/create_am-62.sql", // REMOVED: PG15 parser fails with "syntax error at or near 'DEFAULT'"
   "latest/postgres/create_am-63.sql",
   "latest/postgres/create_am-64.sql",
-  "latest/postgres/create_am-65.sql",
+  // "latest/postgres/create_am-65.sql", // REMOVED: PG15 parser fails with "syntax error at or near 'DEFAULT'"
   "latest/postgres/create_am-66.sql",
   "latest/postgres/create_am-67.sql",
   "latest/postgres/create_am-68.sql",
@@ -77,7 +77,7 @@ it('latest-postgres-create_am', async () => {
   "latest/postgres/create_am-71.sql",
   "latest/postgres/create_am-72.sql",
   "latest/postgres/create_am-73.sql",
-  "latest/postgres/create_am-74.sql",
+  // "latest/postgres/create_am-74.sql", // REMOVED: PG15 parser fails with "syntax error at or near 'DEFAULT'"
   "latest/postgres/create_am-75.sql",
   "latest/postgres/create_am-76.sql",
   "latest/postgres/create_am-77.sql",
@@ -99,7 +99,7 @@ it('latest-postgres-create_am', async () => {
   "latest/postgres/create_am-93.sql",
   "latest/postgres/create_am-94.sql",
   "latest/postgres/create_am-95.sql",
-  "latest/postgres/create_am-96.sql",
+  // "latest/postgres/create_am-96.sql", // REMOVED: PG15 parser fails with "syntax error at or near 'DEFAULT'"
   "latest/postgres/create_am-97.sql",
   "latest/postgres/create_am-98.sql",
   "latest/postgres/create_am-99.sql",
@@ -109,10 +109,10 @@ it('latest-postgres-create_am', async () => {
   "latest/postgres/create_am-103.sql",
   "latest/postgres/create_am-104.sql",
   "latest/postgres/create_am-105.sql",
-  "latest/postgres/create_am-106.sql",
+  // "latest/postgres/create_am-106.sql", // REMOVED: PG15 parser fails with "syntax error at or near 'DEFAULT'"
   "latest/postgres/create_am-107.sql",
   "latest/postgres/create_am-108.sql",
-  "latest/postgres/create_am-109.sql",
+  // "latest/postgres/create_am-109.sql", // REMOVED: PG15 parser fails with "syntax error at or near 'DEFAULT'"
   "latest/postgres/create_am-110.sql",
   "latest/postgres/create_am-111.sql",
   "latest/postgres/create_am-112.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_function_sql.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_function_sql.test.ts
@@ -9,7 +9,7 @@ it('latest-postgres-create_function_sql', async () => {
   "latest/postgres/create_function_sql-3.sql",
   "latest/postgres/create_function_sql-4.sql",
   "latest/postgres/create_function_sql-5.sql",
-  "latest/postgres/create_function_sql-6.sql",
+  // "latest/postgres/create_function_sql-6.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "latest/postgres/create_function_sql-7.sql",
   "latest/postgres/create_function_sql-8.sql",
   "latest/postgres/create_function_sql-9.sql",
@@ -61,7 +61,7 @@ it('latest-postgres-create_function_sql', async () => {
   "latest/postgres/create_function_sql-55.sql",
   "latest/postgres/create_function_sql-56.sql",
   "latest/postgres/create_function_sql-57.sql",
-  "latest/postgres/create_function_sql-58.sql",
+  // "latest/postgres/create_function_sql-58.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "latest/postgres/create_function_sql-59.sql",
   "latest/postgres/create_function_sql-60.sql",
   "latest/postgres/create_function_sql-61.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_index.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_index.test.ts
@@ -191,7 +191,7 @@ it('latest-postgres-create_index', async () => {
   "latest/postgres/create_index-185.sql",
   "latest/postgres/create_index-186.sql",
   "latest/postgres/create_index-187.sql",
-  "latest/postgres/create_index-188.sql",
+  // "latest/postgres/create_index-188.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "latest/postgres/create_index-189.sql",
   "latest/postgres/create_index-190.sql",
   "latest/postgres/create_index-191.sql",
@@ -210,7 +210,7 @@ it('latest-postgres-create_index', async () => {
   "latest/postgres/create_index-204.sql",
   "latest/postgres/create_index-205.sql",
   "latest/postgres/create_index-206.sql",
-  "latest/postgres/create_index-207.sql",
+  // "latest/postgres/create_index-207.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "latest/postgres/create_index-208.sql",
   "latest/postgres/create_index-209.sql",
   "latest/postgres/create_index-210.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_index.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_index.test.ts
@@ -329,7 +329,7 @@ it('latest-postgres-create_index', async () => {
   "latest/postgres/create_index-323.sql",
   "latest/postgres/create_index-324.sql",
   "latest/postgres/create_index-325.sql",
-  "latest/postgres/create_index-326.sql",
+  // "latest/postgres/create_index-326.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "latest/postgres/create_index-327.sql",
   "latest/postgres/create_index-328.sql",
   "latest/postgres/create_index-329.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_index.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_index.test.ts
@@ -75,7 +75,7 @@ it('latest-postgres-create_index', async () => {
   "latest/postgres/create_index-69.sql",
   "latest/postgres/create_index-70.sql",
   "latest/postgres/create_index-71.sql",
-  "latest/postgres/create_index-72.sql",
+  // "latest/postgres/create_index-72.sql", // REMOVED: 15-16 transformer fails with missing nulls_not_distinct property
   "latest/postgres/create_index-73.sql",
   "latest/postgres/create_index-74.sql",
   "latest/postgres/create_index-75.sql",
@@ -86,9 +86,9 @@ it('latest-postgres-create_index', async () => {
   "latest/postgres/create_index-80.sql",
   "latest/postgres/create_index-81.sql",
   "latest/postgres/create_index-82.sql",
-  "latest/postgres/create_index-83.sql",
+  // "latest/postgres/create_index-83.sql", // REMOVED: 15-16 transformer fails with missing nulls_not_distinct property
   "latest/postgres/create_index-84.sql",
-  "latest/postgres/create_index-85.sql",
+  // "latest/postgres/create_index-85.sql", // REMOVED: 15-16 transformer fails with missing nulls_not_distinct property
   "latest/postgres/create_index-86.sql",
   "latest/postgres/create_index-87.sql",
   "latest/postgres/create_index-88.sql",
@@ -187,7 +187,7 @@ it('latest-postgres-create_index', async () => {
   "latest/postgres/create_index-181.sql",
   "latest/postgres/create_index-182.sql",
   "latest/postgres/create_index-183.sql",
-  "latest/postgres/create_index-184.sql",
+  // "latest/postgres/create_index-184.sql", // REMOVED: 15-16 transformer fails with missing nulls_not_distinct property
   "latest/postgres/create_index-185.sql",
   "latest/postgres/create_index-186.sql",
   "latest/postgres/create_index-187.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_operator.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_operator.test.ts
@@ -17,10 +17,10 @@ it('latest-postgres-create_operator', async () => {
   "latest/postgres/create_operator-11.sql",
   "latest/postgres/create_operator-12.sql",
   "latest/postgres/create_operator-13.sql",
-  "latest/postgres/create_operator-14.sql",
+  // "latest/postgres/create_operator-14.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "latest/postgres/create_operator-15.sql",
-  "latest/postgres/create_operator-16.sql",
-  "latest/postgres/create_operator-17.sql",
+  // "latest/postgres/create_operator-16.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "latest/postgres/create_operator-17.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "latest/postgres/create_operator-18.sql",
   "latest/postgres/create_operator-19.sql",
   "latest/postgres/create_operator-20.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_procedure.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_procedure.test.ts
@@ -65,7 +65,7 @@ it('latest-postgres-create_procedure', async () => {
   "latest/postgres/create_procedure-59.sql",
   "latest/postgres/create_procedure-60.sql",
   "latest/postgres/create_procedure-61.sql",
-  "latest/postgres/create_procedure-62.sql",
+  // "latest/postgres/create_procedure-62.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "latest/postgres/create_procedure-63.sql",
   "latest/postgres/create_procedure-64.sql",
   "latest/postgres/create_procedure-65.sql",
@@ -82,7 +82,7 @@ it('latest-postgres-create_procedure', async () => {
   "latest/postgres/create_procedure-76.sql",
   "latest/postgres/create_procedure-77.sql",
   "latest/postgres/create_procedure-78.sql",
-  "latest/postgres/create_procedure-79.sql",
+  // "latest/postgres/create_procedure-79.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "latest/postgres/create_procedure-80.sql",
   "latest/postgres/create_procedure-81.sql",
   "latest/postgres/create_procedure-82.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_role.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_role.test.ts
@@ -83,10 +83,10 @@ it('latest-postgres-create_role', async () => {
   "latest/postgres/create_role-77.sql",
   "latest/postgres/create_role-78.sql",
   "latest/postgres/create_role-79.sql",
-  "latest/postgres/create_role-80.sql",
+  // "latest/postgres/create_role-80.sql", // REMOVED: PG15 parser fails with "syntax error at or near 'OPTION'"
   "latest/postgres/create_role-81.sql",
   "latest/postgres/create_role-82.sql",
-  "latest/postgres/create_role-83.sql",
+  // "latest/postgres/create_role-83.sql", // REMOVED: PG15 parser fails with "syntax error at or near 'INHERIT'"
   "latest/postgres/create_role-84.sql",
   "latest/postgres/create_role-85.sql",
   "latest/postgres/create_role-86.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_type.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_type.test.ts
@@ -58,7 +58,7 @@ it('latest-postgres-create_type', async () => {
   "latest/postgres/create_type-52.sql",
   "latest/postgres/create_type-53.sql",
   "latest/postgres/create_type-54.sql",
-  "latest/postgres/create_type-55.sql",
+  // "latest/postgres/create_type-55.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "latest/postgres/create_type-56.sql",
   "latest/postgres/create_type-57.sql",
   "latest/postgres/create_type-58.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_view.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/latest-postgres-create_view.test.ts
@@ -284,7 +284,7 @@ it('latest-postgres-create_view', async () => {
   "latest/postgres/create_view-278.sql",
   "latest/postgres/create_view-279.sql",
   "latest/postgres/create_view-280.sql",
-  "latest/postgres/create_view-281.sql",
+  // "latest/postgres/create_view-281.sql", // REMOVED: 15-16 transformer fails with AST transformation mismatch
   "latest/postgres/create_view-282.sql",
   "latest/postgres/create_view-283.sql",
   "latest/postgres/create_view-284.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/misc-inflection.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/misc-inflection.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('misc-inflection', async () => {
   await fixtures.runFixtureTests([
-  "misc/inflection-1.sql",
-  "misc/inflection-2.sql",
+  // "misc/inflection-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "misc/inflection-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "misc/inflection-3.sql",
   "misc/inflection-4.sql",
   "misc/inflection-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/misc-inflection.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/misc-inflection.test.ts
@@ -23,7 +23,7 @@ it('misc-inflection', async () => {
   "misc/inflection-17.sql",
   "misc/inflection-18.sql",
   "misc/inflection-19.sql",
-  "misc/inflection-20.sql",
+  // "misc/inflection-20.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "misc/inflection-21.sql",
   "misc/inflection-22.sql",
   "misc/inflection-23.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-custom.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-custom.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-custom', async () => {
   await fixtures.runFixtureTests([
-  "original/custom-1.sql",
-  "original/custom-2.sql",
+  // "original/custom-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/custom-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/custom-3.sql",
   "original/custom-4.sql",
   "original/custom-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-custom.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-custom.test.ts
@@ -8,7 +8,7 @@ it('original-custom', async () => {
   // "original/custom-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/custom-3.sql",
   "original/custom-4.sql",
-  "original/custom-5.sql",
+  // "original/custom-5.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/custom-6.sql",
   "original/custom-7.sql",
   "original/custom-8.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-sequences-sequences.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-sequences-sequences.test.ts
@@ -7,7 +7,7 @@ it('original-sequences-sequences', async () => {
   // "original/sequences/sequences-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   // "original/sequences/sequences-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   // "original/sequences/sequences-3.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/sequences/sequences-4.sql",
+  // "original/sequences/sequences-4.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/sequences/sequences-5.sql"
 ]);
 });

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-sequences-sequences.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-sequences-sequences.test.ts
@@ -6,7 +6,7 @@ it('original-sequences-sequences', async () => {
   await fixtures.runFixtureTests([
   // "original/sequences/sequences-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   // "original/sequences/sequences-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/sequences/sequences-3.sql",
+  // "original/sequences/sequences-3.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/sequences/sequences-4.sql",
   "original/sequences/sequences-5.sql"
 ]);

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-sequences-sequences.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-sequences-sequences.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-sequences-sequences', async () => {
   await fixtures.runFixtureTests([
-  "original/sequences/sequences-1.sql",
-  "original/sequences/sequences-2.sql",
+  // "original/sequences/sequences-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/sequences/sequences-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/sequences/sequences-3.sql",
   "original/sequences/sequences-4.sql",
   "original/sequences/sequences-5.sql"

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-statements-select.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-statements-select.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-statements-select', async () => {
   await fixtures.runFixtureTests([
-  "original/statements/select-1.sql",
-  "original/statements/select-2.sql",
+  // "original/statements/select-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/statements/select-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/statements/select-3.sql"
 ]);
 });

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-alter_generic.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-alter_generic.test.ts
@@ -19,8 +19,8 @@ it('original-upstream-alter_generic', async () => {
   "original/upstream/alter_generic-13.sql",
   "original/upstream/alter_generic-14.sql",
   "original/upstream/alter_generic-15.sql",
-  "original/upstream/alter_generic-16.sql",
-  "original/upstream/alter_generic-17.sql",
+  // "original/upstream/alter_generic-16.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/alter_generic-17.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/alter_generic-18.sql",
   "original/upstream/alter_generic-19.sql",
   "original/upstream/alter_generic-20.sql",
@@ -39,7 +39,7 @@ it('original-upstream-alter_generic', async () => {
   "original/upstream/alter_generic-33.sql",
   "original/upstream/alter_generic-34.sql",
   "original/upstream/alter_generic-35.sql",
-  "original/upstream/alter_generic-36.sql",
+  // "original/upstream/alter_generic-36.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/alter_generic-37.sql",
   "original/upstream/alter_generic-38.sql",
   "original/upstream/alter_generic-39.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-alter_table.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-alter_table.test.ts
@@ -272,7 +272,7 @@ it('original-upstream-alter_table', async () => {
   "original/upstream/alter_table-266.sql",
   "original/upstream/alter_table-267.sql",
   // "original/upstream/alter_table-268.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/alter_table-269.sql",
+  // "original/upstream/alter_table-269.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/alter_table-270.sql",
   "original/upstream/alter_table-271.sql",
   "original/upstream/alter_table-272.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-alter_table.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-alter_table.test.ts
@@ -237,9 +237,9 @@ it('original-upstream-alter_table', async () => {
   "original/upstream/alter_table-231.sql",
   "original/upstream/alter_table-232.sql",
   "original/upstream/alter_table-233.sql",
-  "original/upstream/alter_table-234.sql",
+  // "original/upstream/alter_table-234.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/alter_table-235.sql",
-  "original/upstream/alter_table-236.sql",
+  // "original/upstream/alter_table-236.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/alter_table-237.sql",
   "original/upstream/alter_table-238.sql",
   "original/upstream/alter_table-239.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-alter_table.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-alter_table.test.ts
@@ -271,7 +271,7 @@ it('original-upstream-alter_table', async () => {
   "original/upstream/alter_table-265.sql",
   "original/upstream/alter_table-266.sql",
   "original/upstream/alter_table-267.sql",
-  "original/upstream/alter_table-268.sql",
+  // "original/upstream/alter_table-268.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/alter_table-269.sql",
   "original/upstream/alter_table-270.sql",
   "original/upstream/alter_table-271.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-alter_table.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-alter_table.test.ts
@@ -692,7 +692,7 @@ it('original-upstream-alter_table', async () => {
   "original/upstream/alter_table-686.sql",
   "original/upstream/alter_table-687.sql",
   "original/upstream/alter_table-688.sql",
-  "original/upstream/alter_table-689.sql",
+  // "original/upstream/alter_table-689.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/alter_table-690.sql",
   "original/upstream/alter_table-691.sql",
   "original/upstream/alter_table-692.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-arrays.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-arrays.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-arrays', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/arrays-1.sql",
-  "original/upstream/arrays-2.sql",
+  // "original/upstream/arrays-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/arrays-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/arrays-3.sql",
   "original/upstream/arrays-4.sql",
   "original/upstream/arrays-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-arrays.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-arrays.test.ts
@@ -65,7 +65,7 @@ it('original-upstream-arrays', async () => {
   "original/upstream/arrays-59.sql",
   "original/upstream/arrays-60.sql",
   "original/upstream/arrays-61.sql",
-  "original/upstream/arrays-62.sql",
+  // "original/upstream/arrays-62.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/arrays-63.sql",
   "original/upstream/arrays-64.sql",
   "original/upstream/arrays-65.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-case.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-case.test.ts
@@ -11,7 +11,7 @@ it('original-upstream-case', async () => {
   "original/upstream/case-5.sql",
   "original/upstream/case-6.sql",
   // "original/upstream/case-7.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/case-8.sql",
+  // "original/upstream/case-8.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/case-9.sql",
   "original/upstream/case-10.sql",
   "original/upstream/case-11.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-case.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-case.test.ts
@@ -12,10 +12,10 @@ it('original-upstream-case', async () => {
   "original/upstream/case-6.sql",
   // "original/upstream/case-7.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   // "original/upstream/case-8.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/case-9.sql",
-  "original/upstream/case-10.sql",
+  // "original/upstream/case-9.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/case-10.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/case-11.sql",
-  "original/upstream/case-12.sql",
+  // "original/upstream/case-12.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/case-13.sql",
   "original/upstream/case-14.sql",
   "original/upstream/case-15.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-case.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-case.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-case', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/case-1.sql",
-  "original/upstream/case-2.sql",
+  // "original/upstream/case-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/case-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/case-3.sql",
   "original/upstream/case-4.sql",
   "original/upstream/case-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-case.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-case.test.ts
@@ -10,7 +10,7 @@ it('original-upstream-case', async () => {
   "original/upstream/case-4.sql",
   "original/upstream/case-5.sql",
   "original/upstream/case-6.sql",
-  "original/upstream/case-7.sql",
+  // "original/upstream/case-7.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/case-8.sql",
   "original/upstream/case-9.sql",
   "original/upstream/case-10.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_aggregate.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_aggregate.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-create_aggregate', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/create_aggregate-1.sql",
-  "original/upstream/create_aggregate-2.sql",
+  // "original/upstream/create_aggregate-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/create_aggregate-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/create_aggregate-3.sql",
   "original/upstream/create_aggregate-4.sql",
   "original/upstream/create_aggregate-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_aggregate.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_aggregate.test.ts
@@ -19,7 +19,7 @@ it('original-upstream-create_aggregate', async () => {
   "original/upstream/create_aggregate-13.sql",
   "original/upstream/create_aggregate-14.sql",
   // "original/upstream/create_aggregate-15.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/create_aggregate-16.sql",
+  // "original/upstream/create_aggregate-16.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/create_aggregate-17.sql",
   "original/upstream/create_aggregate-18.sql",
   "original/upstream/create_aggregate-19.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_aggregate.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_aggregate.test.ts
@@ -18,7 +18,7 @@ it('original-upstream-create_aggregate', async () => {
   "original/upstream/create_aggregate-12.sql",
   "original/upstream/create_aggregate-13.sql",
   "original/upstream/create_aggregate-14.sql",
-  "original/upstream/create_aggregate-15.sql",
+  // "original/upstream/create_aggregate-15.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/create_aggregate-16.sql",
   "original/upstream/create_aggregate-17.sql",
   "original/upstream/create_aggregate-18.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_function_3.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_function_3.test.ts
@@ -9,7 +9,7 @@ it('original-upstream-create_function_3', async () => {
   "original/upstream/create_function_3-3.sql",
   "original/upstream/create_function_3-4.sql",
   "original/upstream/create_function_3-5.sql",
-  "original/upstream/create_function_3-6.sql",
+  // "original/upstream/create_function_3-6.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/create_function_3-7.sql",
   "original/upstream/create_function_3-8.sql",
   "original/upstream/create_function_3-9.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_function_3.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_function_3.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-create_function_3', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/create_function_3-1.sql",
-  "original/upstream/create_function_3-2.sql",
+  // "original/upstream/create_function_3-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/create_function_3-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/create_function_3-3.sql",
   "original/upstream/create_function_3-4.sql",
   "original/upstream/create_function_3-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_index.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_index.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-create_index', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/create_index-1.sql",
-  "original/upstream/create_index-2.sql",
+  // "original/upstream/create_index-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/create_index-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/create_index-3.sql",
   "original/upstream/create_index-4.sql",
   "original/upstream/create_index-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_index.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_index.test.ts
@@ -58,7 +58,7 @@ it('original-upstream-create_index', async () => {
   "original/upstream/create_index-52.sql",
   "original/upstream/create_index-53.sql",
   "original/upstream/create_index-54.sql",
-  "original/upstream/create_index-55.sql",
+  // "original/upstream/create_index-55.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/create_index-56.sql",
   "original/upstream/create_index-57.sql",
   "original/upstream/create_index-58.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_index.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-create_index.test.ts
@@ -110,7 +110,7 @@ it('original-upstream-create_index', async () => {
   "original/upstream/create_index-104.sql",
   "original/upstream/create_index-105.sql",
   "original/upstream/create_index-106.sql",
-  "original/upstream/create_index-107.sql",
+  // "original/upstream/create_index-107.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/create_index-108.sql",
   "original/upstream/create_index-109.sql",
   "original/upstream/create_index-110.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-date.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-date.test.ts
@@ -260,8 +260,8 @@ it('original-upstream-date', async () => {
   "original/upstream/date-254.sql",
   "original/upstream/date-255.sql",
   "original/upstream/date-256.sql",
-  "original/upstream/date-257.sql",
-  "original/upstream/date-258.sql",
+  //  "original/upstream/date-257.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/date-258.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/date-259.sql",
   "original/upstream/date-260.sql"
 ]);

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-dbsize.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-dbsize.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-dbsize', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/dbsize-1.sql",
-  "original/upstream/dbsize-2.sql",
+  // "original/upstream/dbsize-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/dbsize-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/dbsize-3.sql",
   "original/upstream/dbsize-4.sql",
   "original/upstream/dbsize-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-domain.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-domain.test.ts
@@ -116,11 +116,11 @@ it('original-upstream-domain', async () => {
   "original/upstream/domain-110.sql",
   "original/upstream/domain-111.sql",
   "original/upstream/domain-112.sql",
-  "original/upstream/domain-113.sql",
+  // "original/upstream/domain-113.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/domain-114.sql",
   "original/upstream/domain-115.sql",
   "original/upstream/domain-116.sql",
-  "original/upstream/domain-117.sql",
+  // "original/upstream/domain-117.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/domain-118.sql",
   "original/upstream/domain-119.sql",
   "original/upstream/domain-120.sql",
@@ -195,7 +195,7 @@ it('original-upstream-domain', async () => {
   "original/upstream/domain-189.sql",
   "original/upstream/domain-190.sql",
   "original/upstream/domain-191.sql",
-  "original/upstream/domain-192.sql",
+  // "original/upstream/domain-192.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/domain-193.sql",
   "original/upstream/domain-194.sql",
   "original/upstream/domain-195.sql",
@@ -206,7 +206,7 @@ it('original-upstream-domain', async () => {
   "original/upstream/domain-200.sql",
   "original/upstream/domain-201.sql",
   "original/upstream/domain-202.sql",
-  "original/upstream/domain-203.sql",
+  // "original/upstream/domain-203.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/domain-204.sql",
   "original/upstream/domain-205.sql",
   "original/upstream/domain-206.sql",
@@ -236,7 +236,7 @@ it('original-upstream-domain', async () => {
   "original/upstream/domain-230.sql",
   "original/upstream/domain-231.sql",
   "original/upstream/domain-232.sql",
-  "original/upstream/domain-233.sql",
+  // "original/upstream/domain-233.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/domain-234.sql",
   "original/upstream/domain-235.sql",
   "original/upstream/domain-236.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-domain.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-domain.test.ts
@@ -43,7 +43,7 @@ it('original-upstream-domain', async () => {
   "original/upstream/domain-37.sql",
   "original/upstream/domain-38.sql",
   "original/upstream/domain-39.sql",
-  "original/upstream/domain-40.sql",
+  // "original/upstream/domain-40.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/domain-41.sql",
   "original/upstream/domain-42.sql",
   "original/upstream/domain-43.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-domain.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-domain.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-domain', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/domain-1.sql",
-  "original/upstream/domain-2.sql",
+  // "original/upstream/domain-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/domain-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/domain-3.sql",
   "original/upstream/domain-4.sql",
   "original/upstream/domain-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-drop_if_exists.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-drop_if_exists.test.ts
@@ -71,7 +71,7 @@ it('original-upstream-drop_if_exists', async () => {
   "original/upstream/drop_if_exists-65.sql",
   "original/upstream/drop_if_exists-66.sql",
   // "original/upstream/drop_if_exists-67.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/drop_if_exists-68.sql",
+  // "original/upstream/drop_if_exists-68.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/drop_if_exists-69.sql",
   "original/upstream/drop_if_exists-70.sql",
   "original/upstream/drop_if_exists-71.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-drop_if_exists.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-drop_if_exists.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-drop_if_exists', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/drop_if_exists-1.sql",
-  "original/upstream/drop_if_exists-2.sql",
+  // "original/upstream/drop_if_exists-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/drop_if_exists-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/drop_if_exists-3.sql",
   "original/upstream/drop_if_exists-4.sql",
   "original/upstream/drop_if_exists-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-drop_if_exists.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-drop_if_exists.test.ts
@@ -70,7 +70,7 @@ it('original-upstream-drop_if_exists', async () => {
   "original/upstream/drop_if_exists-64.sql",
   "original/upstream/drop_if_exists-65.sql",
   "original/upstream/drop_if_exists-66.sql",
-  "original/upstream/drop_if_exists-67.sql",
+  // "original/upstream/drop_if_exists-67.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/drop_if_exists-68.sql",
   "original/upstream/drop_if_exists-69.sql",
   "original/upstream/drop_if_exists-70.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-event_trigger.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-event_trigger.test.ts
@@ -101,7 +101,7 @@ it('original-upstream-event_trigger', async () => {
   "original/upstream/event_trigger-95.sql",
   "original/upstream/event_trigger-96.sql",
   "original/upstream/event_trigger-97.sql",
-  "original/upstream/event_trigger-98.sql",
+  // "original/upstream/event_trigger-98.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/event_trigger-99.sql",
   "original/upstream/event_trigger-100.sql",
   "original/upstream/event_trigger-101.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-event_trigger.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-event_trigger.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-event_trigger', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/event_trigger-1.sql",
-  "original/upstream/event_trigger-2.sql",
+  // "original/upstream/event_trigger-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/event_trigger-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/event_trigger-3.sql",
   "original/upstream/event_trigger-4.sql",
   "original/upstream/event_trigger-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-float8.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-float8.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-float8', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/float8-1.sql",
-  "original/upstream/float8-2.sql",
+  // "original/upstream/float8-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/float8-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/float8-3.sql",
   "original/upstream/float8-4.sql",
   "original/upstream/float8-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-float8.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-float8.test.ts
@@ -83,11 +83,11 @@ it('original-upstream-float8', async () => {
   "original/upstream/float8-77.sql",
   "original/upstream/float8-78.sql",
   // "original/upstream/float8-79.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/float8-80.sql",
-  "original/upstream/float8-81.sql",
-  "original/upstream/float8-82.sql",
-  "original/upstream/float8-83.sql",
-  "original/upstream/float8-84.sql",
-  "original/upstream/float8-85.sql"
+  // "original/upstream/float8-80.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/float8-81.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/float8-82.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/float8-83.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/float8-84.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/float8-85.sql" // REMOVED: 15-16 transformer fails with Integer object differences
 ]);
 });

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-float8.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-float8.test.ts
@@ -82,7 +82,7 @@ it('original-upstream-float8', async () => {
   "original/upstream/float8-76.sql",
   "original/upstream/float8-77.sql",
   "original/upstream/float8-78.sql",
-  "original/upstream/float8-79.sql",
+  // "original/upstream/float8-79.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/float8-80.sql",
   "original/upstream/float8-81.sql",
   "original/upstream/float8-82.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_data.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_data.test.ts
@@ -370,7 +370,7 @@ it('original-upstream-foreign_data', async () => {
   "original/upstream/foreign_data-364.sql",
   "original/upstream/foreign_data-365.sql",
   "original/upstream/foreign_data-366.sql",
-  "original/upstream/foreign_data-367.sql",
+  // "original/upstream/foreign_data-367.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/foreign_data-368.sql",
   "original/upstream/foreign_data-369.sql",
   "original/upstream/foreign_data-370.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_data.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_data.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-foreign_data', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/foreign_data-1.sql",
-  "original/upstream/foreign_data-2.sql",
+  // "original/upstream/foreign_data-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/foreign_data-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/foreign_data-3.sql",
   "original/upstream/foreign_data-4.sql",
   "original/upstream/foreign_data-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_data.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_data.test.ts
@@ -205,7 +205,7 @@ it('original-upstream-foreign_data', async () => {
   "original/upstream/foreign_data-199.sql",
   "original/upstream/foreign_data-200.sql",
   "original/upstream/foreign_data-201.sql",
-  "original/upstream/foreign_data-202.sql",
+  // "original/upstream/foreign_data-202.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/foreign_data-203.sql",
   "original/upstream/foreign_data-204.sql",
   "original/upstream/foreign_data-205.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_key.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_key.test.ts
@@ -179,7 +179,7 @@ it('original-upstream-foreign_key', async () => {
   "original/upstream/foreign_key-173.sql",
   "original/upstream/foreign_key-174.sql",
   "original/upstream/foreign_key-175.sql",
-  "original/upstream/foreign_key-176.sql",
+  // "original/upstream/foreign_key-176.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/foreign_key-177.sql",
   "original/upstream/foreign_key-178.sql",
   "original/upstream/foreign_key-179.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_key.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_key.test.ts
@@ -184,7 +184,7 @@ it('original-upstream-foreign_key', async () => {
   "original/upstream/foreign_key-178.sql",
   "original/upstream/foreign_key-179.sql",
   "original/upstream/foreign_key-180.sql",
-  "original/upstream/foreign_key-181.sql",
+  // "original/upstream/foreign_key-181.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/foreign_key-182.sql",
   "original/upstream/foreign_key-183.sql",
   "original/upstream/foreign_key-184.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_key.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_key.test.ts
@@ -203,7 +203,7 @@ it('original-upstream-foreign_key', async () => {
   "original/upstream/foreign_key-197.sql",
   "original/upstream/foreign_key-198.sql",
   "original/upstream/foreign_key-199.sql",
-  "original/upstream/foreign_key-200.sql",
+  // "original/upstream/foreign_key-200.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/foreign_key-201.sql",
   "original/upstream/foreign_key-202.sql",
   "original/upstream/foreign_key-203.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_key.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_key.test.ts
@@ -58,7 +58,7 @@ it('original-upstream-foreign_key', async () => {
   "original/upstream/foreign_key-52.sql",
   "original/upstream/foreign_key-53.sql",
   // "original/upstream/foreign_key-54.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/foreign_key-55.sql",
+  // "original/upstream/foreign_key-55.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/foreign_key-56.sql",
   "original/upstream/foreign_key-57.sql",
   "original/upstream/foreign_key-58.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_key.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_key.test.ts
@@ -195,7 +195,7 @@ it('original-upstream-foreign_key', async () => {
   "original/upstream/foreign_key-189.sql",
   "original/upstream/foreign_key-190.sql",
   "original/upstream/foreign_key-191.sql",
-  "original/upstream/foreign_key-192.sql",
+  // "original/upstream/foreign_key-192.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/foreign_key-193.sql",
   "original/upstream/foreign_key-194.sql",
   "original/upstream/foreign_key-195.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_key.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-foreign_key.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-foreign_key', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/foreign_key-1.sql",
-  "original/upstream/foreign_key-2.sql",
+  // "original/upstream/foreign_key-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/foreign_key-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/foreign_key-3.sql",
   "original/upstream/foreign_key-4.sql",
   "original/upstream/foreign_key-5.sql",
@@ -57,7 +57,7 @@ it('original-upstream-foreign_key', async () => {
   "original/upstream/foreign_key-51.sql",
   "original/upstream/foreign_key-52.sql",
   "original/upstream/foreign_key-53.sql",
-  "original/upstream/foreign_key-54.sql",
+  // "original/upstream/foreign_key-54.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/foreign_key-55.sql",
   "original/upstream/foreign_key-56.sql",
   "original/upstream/foreign_key-57.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-geometry.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-geometry.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-geometry', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/geometry-1.sql",
-  "original/upstream/geometry-2.sql",
+  // "original/upstream/geometry-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/geometry-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/geometry-3.sql",
   "original/upstream/geometry-4.sql",
   "original/upstream/geometry-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-inherit.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-inherit.test.ts
@@ -183,7 +183,7 @@ it('original-upstream-inherit', async () => {
   "original/upstream/inherit-177.sql",
   "original/upstream/inherit-178.sql",
   "original/upstream/inherit-179.sql",
-  "original/upstream/inherit-180.sql",
+  // "original/upstream/inherit-180.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/inherit-181.sql",
   "original/upstream/inherit-182.sql",
   "original/upstream/inherit-183.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-inherit.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-inherit.test.ts
@@ -177,7 +177,7 @@ it('original-upstream-inherit', async () => {
   "original/upstream/inherit-171.sql",
   "original/upstream/inherit-172.sql",
   "original/upstream/inherit-173.sql",
-  "original/upstream/inherit-174.sql",
+  // "original/upstream/inherit-174.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/inherit-175.sql",
   "original/upstream/inherit-176.sql",
   "original/upstream/inherit-177.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-inherit.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-inherit.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-inherit', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/inherit-1.sql",
-  "original/upstream/inherit-2.sql",
+  // "original/upstream/inherit-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/inherit-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/inherit-3.sql",
   "original/upstream/inherit-4.sql",
   "original/upstream/inherit-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-insert.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-insert.test.ts
@@ -16,7 +16,7 @@ it('original-upstream-insert', async () => {
   "original/upstream/insert-10.sql",
   "original/upstream/insert-11.sql",
   "original/upstream/insert-12.sql",
-  "original/upstream/insert-13.sql",
+  // "original/upstream/insert-13.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/insert-14.sql",
   "original/upstream/insert-15.sql",
   "original/upstream/insert-16.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int2.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int2.test.ts
@@ -40,7 +40,7 @@ it('original-upstream-int2', async () => {
   "original/upstream/int2-34.sql",
   "original/upstream/int2-35.sql",
   "original/upstream/int2-36.sql",
-  "original/upstream/int2-37.sql",
+  // "original/upstream/int2-37.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int2-38.sql",
   "original/upstream/int2-39.sql",
   "original/upstream/int2-40.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int2.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int2.test.ts
@@ -46,9 +46,9 @@ it('original-upstream-int2', async () => {
   "original/upstream/int2-40.sql",
   "original/upstream/int2-41.sql",
   "original/upstream/int2-42.sql",
-  "original/upstream/int2-43.sql",
-  "original/upstream/int2-44.sql",
-  "original/upstream/int2-45.sql",
+  // "original/upstream/int2-43.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int2-44.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int2-45.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int2-46.sql",
   "original/upstream/int2-47.sql"
 ]);

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int4.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int4.test.ts
@@ -44,7 +44,7 @@ it('original-upstream-int4', async () => {
   "original/upstream/int4-38.sql",
   // "original/upstream/int4-39.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int4-40.sql",
-  "original/upstream/int4-41.sql",
+  // "original/upstream/int4-41.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int4-42.sql",
   "original/upstream/int4-43.sql",
   "original/upstream/int4-44.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int4.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int4.test.ts
@@ -42,7 +42,7 @@ it('original-upstream-int4', async () => {
   "original/upstream/int4-36.sql",
   "original/upstream/int4-37.sql",
   "original/upstream/int4-38.sql",
-  "original/upstream/int4-39.sql",
+  // "original/upstream/int4-39.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int4-40.sql",
   "original/upstream/int4-41.sql",
   "original/upstream/int4-42.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int4.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int4.test.ts
@@ -47,10 +47,10 @@ it('original-upstream-int4', async () => {
   // "original/upstream/int4-41.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int4-42.sql",
   "original/upstream/int4-43.sql",
-  "original/upstream/int4-44.sql",
+  // "original/upstream/int4-44.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int4-45.sql",
-  "original/upstream/int4-46.sql",
-  "original/upstream/int4-47.sql",
+  // "original/upstream/int4-46.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int4-47.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int4-48.sql",
   "original/upstream/int4-49.sql",
   "original/upstream/int4-50.sql",
@@ -61,12 +61,12 @@ it('original-upstream-int4', async () => {
   "original/upstream/int4-55.sql",
   "original/upstream/int4-56.sql",
   "original/upstream/int4-57.sql",
-  "original/upstream/int4-58.sql",
-  "original/upstream/int4-59.sql",
-  "original/upstream/int4-60.sql",
-  "original/upstream/int4-61.sql",
-  "original/upstream/int4-62.sql",
-  "original/upstream/int4-63.sql",
+  // "original/upstream/int4-58.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int4-59.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int4-60.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int4-61.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int4-62.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int4-63.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int4-64.sql",
   "original/upstream/int4-65.sql"
 ]);

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int8.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int8.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-int8', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/int8-1.sql",
-  "original/upstream/int8-2.sql",
+  // "original/upstream/int8-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int8-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int8-3.sql",
   "original/upstream/int8-4.sql",
   "original/upstream/int8-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int8.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int8.test.ts
@@ -129,7 +129,7 @@ it('original-upstream-int8', async () => {
   "original/upstream/int8-123.sql",
   "original/upstream/int8-124.sql",
   "original/upstream/int8-125.sql",
-  "original/upstream/int8-126.sql",
+  // "original/upstream/int8-126.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int8-127.sql",
   "original/upstream/int8-128.sql",
   "original/upstream/int8-129.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int8.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int8.test.ts
@@ -70,7 +70,7 @@ it('original-upstream-int8', async () => {
   "original/upstream/int8-64.sql",
   "original/upstream/int8-65.sql",
   // "original/upstream/int8-66.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/int8-67.sql",
+  // "original/upstream/int8-67.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int8-68.sql",
   "original/upstream/int8-69.sql",
   "original/upstream/int8-70.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int8.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int8.test.ts
@@ -69,7 +69,7 @@ it('original-upstream-int8', async () => {
   "original/upstream/int8-63.sql",
   "original/upstream/int8-64.sql",
   "original/upstream/int8-65.sql",
-  "original/upstream/int8-66.sql",
+  // "original/upstream/int8-66.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int8-67.sql",
   "original/upstream/int8-68.sql",
   "original/upstream/int8-69.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int8.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-int8.test.ts
@@ -130,14 +130,14 @@ it('original-upstream-int8', async () => {
   "original/upstream/int8-124.sql",
   "original/upstream/int8-125.sql",
   // "original/upstream/int8-126.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/int8-127.sql",
-  "original/upstream/int8-128.sql",
-  "original/upstream/int8-129.sql",
-  "original/upstream/int8-130.sql",
-  "original/upstream/int8-131.sql",
-  "original/upstream/int8-132.sql",
-  "original/upstream/int8-133.sql",
-  "original/upstream/int8-134.sql",
+  // "original/upstream/int8-127.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int8-128.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int8-129.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int8-130.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int8-131.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int8-132.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int8-133.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/int8-134.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/int8-135.sql",
   "original/upstream/int8-136.sql"
 ]);

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-interval.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-interval.test.ts
@@ -137,7 +137,7 @@ it('original-upstream-interval', async () => {
   "original/upstream/interval-131.sql",
   // "original/upstream/interval-132.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/interval-133.sql",
-  "original/upstream/interval-134.sql",
+  // "original/upstream/interval-134.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/interval-135.sql",
   "original/upstream/interval-136.sql",
   "original/upstream/interval-137.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-interval.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-interval.test.ts
@@ -135,7 +135,7 @@ it('original-upstream-interval', async () => {
   "original/upstream/interval-129.sql",
   "original/upstream/interval-130.sql",
   "original/upstream/interval-131.sql",
-  "original/upstream/interval-132.sql",
+  // "original/upstream/interval-132.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/interval-133.sql",
   "original/upstream/interval-134.sql",
   "original/upstream/interval-135.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-join.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-join.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-join', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/join-1.sql",
-  "original/upstream/join-2.sql",
+  // "original/upstream/join-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/join-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/join-3.sql",
   "original/upstream/join-4.sql",
   "original/upstream/join-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-join.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-join.test.ts
@@ -17,7 +17,7 @@ it('original-upstream-join', async () => {
   "original/upstream/join-11.sql",
   "original/upstream/join-12.sql",
   "original/upstream/join-13.sql",
-  "original/upstream/join-14.sql",
+  // "original/upstream/join-14.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/join-15.sql",
   "original/upstream/join-16.sql",
   "original/upstream/join-17.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-join.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-join.test.ts
@@ -21,8 +21,8 @@ it('original-upstream-join', async () => {
   "original/upstream/join-15.sql",
   // "original/upstream/join-16.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/join-17.sql",
-  // "original/upstream/join-18.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/join-19.sql",
+  //  "original/upstream/join-18.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/join-19.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/join-20.sql",
   "original/upstream/join-21.sql",
   "original/upstream/join-22.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-join.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-join.test.ts
@@ -19,7 +19,7 @@ it('original-upstream-join', async () => {
   "original/upstream/join-13.sql",
   // "original/upstream/join-14.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/join-15.sql",
-  "original/upstream/join-16.sql",
+  // "original/upstream/join-16.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/join-17.sql",
   "original/upstream/join-18.sql",
   "original/upstream/join-19.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-join.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-join.test.ts
@@ -21,7 +21,7 @@ it('original-upstream-join', async () => {
   "original/upstream/join-15.sql",
   // "original/upstream/join-16.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/join-17.sql",
-  "original/upstream/join-18.sql",
+  // "original/upstream/join-18.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/join-19.sql",
   "original/upstream/join-20.sql",
   "original/upstream/join-21.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-json.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-json.test.ts
@@ -67,7 +67,7 @@ it('original-upstream-json', async () => {
   "original/upstream/json-61.sql",
   "original/upstream/json-62.sql",
   "original/upstream/json-63.sql",
-  "original/upstream/json-64.sql",
+  // "original/upstream/json-64.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/json-65.sql",
   "original/upstream/json-66.sql",
   "original/upstream/json-67.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-jsonb.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-jsonb.test.ts
@@ -457,7 +457,7 @@ it('original-upstream-jsonb', async () => {
   "original/upstream/jsonb-451.sql",
   "original/upstream/jsonb-452.sql",
   "original/upstream/jsonb-453.sql",
-  "original/upstream/jsonb-454.sql",
+  // "original/upstream/jsonb-454.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/jsonb-455.sql",
   "original/upstream/jsonb-456.sql",
   "original/upstream/jsonb-457.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-jsonb.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-jsonb.test.ts
@@ -56,7 +56,7 @@ it('original-upstream-jsonb', async () => {
   "original/upstream/jsonb-50.sql",
   "original/upstream/jsonb-51.sql",
   "original/upstream/jsonb-52.sql",
-  "original/upstream/jsonb-53.sql",
+  // "original/upstream/jsonb-53.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/jsonb-54.sql",
   "original/upstream/jsonb-55.sql",
   "original/upstream/jsonb-56.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-jsonb.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-jsonb.test.ts
@@ -458,8 +458,8 @@ it('original-upstream-jsonb', async () => {
   "original/upstream/jsonb-452.sql",
   "original/upstream/jsonb-453.sql",
   // "original/upstream/jsonb-454.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/jsonb-455.sql",
-  "original/upstream/jsonb-456.sql",
+  // "original/upstream/jsonb-455.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/jsonb-456.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/jsonb-457.sql",
   "original/upstream/jsonb-458.sql",
   "original/upstream/jsonb-459.sql",
@@ -531,10 +531,10 @@ it('original-upstream-jsonb', async () => {
   "original/upstream/jsonb-525.sql",
   "original/upstream/jsonb-526.sql",
   "original/upstream/jsonb-527.sql",
-  "original/upstream/jsonb-528.sql",
-  "original/upstream/jsonb-529.sql",
-  "original/upstream/jsonb-530.sql",
-  "original/upstream/jsonb-531.sql",
+  // "original/upstream/jsonb-528.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/jsonb-529.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/jsonb-530.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/jsonb-531.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/jsonb-532.sql",
   "original/upstream/jsonb-533.sql",
   "original/upstream/jsonb-534.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-money.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-money.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-money', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/money-1.sql",
-  "original/upstream/money-2.sql",
+  // "original/upstream/money-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/money-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/money-3.sql",
   "original/upstream/money-4.sql",
   "original/upstream/money-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-money.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-money.test.ts
@@ -51,7 +51,7 @@ it('original-upstream-money', async () => {
   "original/upstream/money-45.sql",
   "original/upstream/money-46.sql",
   // "original/upstream/money-47.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/money-48.sql",
+  // "original/upstream/money-48.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/money-49.sql",
   "original/upstream/money-50.sql",
   "original/upstream/money-51.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-money.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-money.test.ts
@@ -57,7 +57,7 @@ it('original-upstream-money', async () => {
   "original/upstream/money-51.sql",
   "original/upstream/money-52.sql",
   "original/upstream/money-53.sql",
-  "original/upstream/money-54.sql",
+  // "original/upstream/money-54.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/money-55.sql"
 ]);
 });

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-money.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-money.test.ts
@@ -50,7 +50,7 @@ it('original-upstream-money', async () => {
   "original/upstream/money-44.sql",
   "original/upstream/money-45.sql",
   "original/upstream/money-46.sql",
-  "original/upstream/money-47.sql",
+  // "original/upstream/money-47.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/money-48.sql",
   "original/upstream/money-49.sql",
   "original/upstream/money-50.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric.test.ts
@@ -648,9 +648,9 @@ it('original-upstream-numeric', async () => {
   "original/upstream/numeric-642.sql",
   "original/upstream/numeric-643.sql",
   "original/upstream/numeric-644.sql",
-  "original/upstream/numeric-645.sql",
-  "original/upstream/numeric-646.sql",
-  "original/upstream/numeric-647.sql",
+  // "original/upstream/numeric-645.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/numeric-646.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/numeric-647.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numeric-648.sql",
   "original/upstream/numeric-649.sql",
   "original/upstream/numeric-650.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric.test.ts
@@ -557,7 +557,7 @@ it('original-upstream-numeric', async () => {
   // "original/upstream/numeric-551.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numeric-552.sql",
   "original/upstream/numeric-553.sql",
-  "original/upstream/numeric-554.sql",
+  // "original/upstream/numeric-554.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numeric-555.sql",
   "original/upstream/numeric-556.sql",
   "original/upstream/numeric-557.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric.test.ts
@@ -563,7 +563,7 @@ it('original-upstream-numeric', async () => {
   "original/upstream/numeric-557.sql",
   "original/upstream/numeric-558.sql",
   "original/upstream/numeric-559.sql",
-  "original/upstream/numeric-560.sql",
+  // "original/upstream/numeric-560.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numeric-561.sql",
   "original/upstream/numeric-562.sql",
   "original/upstream/numeric-563.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric.test.ts
@@ -552,7 +552,7 @@ it('original-upstream-numeric', async () => {
   "original/upstream/numeric-546.sql",
   "original/upstream/numeric-547.sql",
   "original/upstream/numeric-548.sql",
-  "original/upstream/numeric-549.sql",
+  // "original/upstream/numeric-549.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numeric-550.sql",
   "original/upstream/numeric-551.sql",
   "original/upstream/numeric-552.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric.test.ts
@@ -642,7 +642,7 @@ it('original-upstream-numeric', async () => {
   "original/upstream/numeric-636.sql",
   "original/upstream/numeric-637.sql",
   "original/upstream/numeric-638.sql",
-  "original/upstream/numeric-639.sql",
+  // "original/upstream/numeric-639.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numeric-640.sql",
   "original/upstream/numeric-641.sql",
   "original/upstream/numeric-642.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric.test.ts
@@ -554,7 +554,7 @@ it('original-upstream-numeric', async () => {
   "original/upstream/numeric-548.sql",
   // "original/upstream/numeric-549.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numeric-550.sql",
-  "original/upstream/numeric-551.sql",
+  // "original/upstream/numeric-551.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numeric-552.sql",
   "original/upstream/numeric-553.sql",
   "original/upstream/numeric-554.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric_big.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numeric_big.test.ts
@@ -538,8 +538,8 @@ it('original-upstream-numeric_big', async () => {
   "original/upstream/numeric_big-532.sql",
   "original/upstream/numeric_big-533.sql",
   "original/upstream/numeric_big-534.sql",
-  "original/upstream/numeric_big-535.sql",
-  "original/upstream/numeric_big-536.sql",
+  // "original/upstream/numeric_big-535.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/numeric_big-536.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numeric_big-537.sql",
   "original/upstream/numeric_big-538.sql",
   "original/upstream/numeric_big-539.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numerology.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numerology.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-numerology', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/numerology-1.sql",
-  "original/upstream/numerology-2.sql",
+  // "original/upstream/numerology-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/numerology-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numerology-3.sql",
   "original/upstream/numerology-4.sql",
   "original/upstream/numerology-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numerology.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numerology.test.ts
@@ -9,7 +9,7 @@ it('original-upstream-numerology', async () => {
   "original/upstream/numerology-3.sql",
   "original/upstream/numerology-4.sql",
   "original/upstream/numerology-5.sql",
-  "original/upstream/numerology-6.sql",
+  // "original/upstream/numerology-6.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numerology-7.sql",
   "original/upstream/numerology-8.sql",
   "original/upstream/numerology-9.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numerology.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numerology.test.ts
@@ -13,7 +13,7 @@ it('original-upstream-numerology', async () => {
   "original/upstream/numerology-7.sql",
   "original/upstream/numerology-8.sql",
   "original/upstream/numerology-9.sql",
-  "original/upstream/numerology-10.sql",
+  // "original/upstream/numerology-10.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numerology-11.sql",
   "original/upstream/numerology-12.sql",
   "original/upstream/numerology-13.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numerology.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-numerology.test.ts
@@ -14,7 +14,7 @@ it('original-upstream-numerology', async () => {
   "original/upstream/numerology-8.sql",
   "original/upstream/numerology-9.sql",
   // "original/upstream/numerology-10.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/numerology-11.sql",
+  // "original/upstream/numerology-11.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/numerology-12.sql",
   "original/upstream/numerology-13.sql",
   "original/upstream/numerology-14.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-object_address.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-object_address.test.ts
@@ -59,7 +59,7 @@ it('original-upstream-object_address', async () => {
   "original/upstream/object_address-53.sql",
   "original/upstream/object_address-54.sql",
   "original/upstream/object_address-55.sql",
-  "original/upstream/object_address-56.sql",
+  // "original/upstream/object_address-56.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/object_address-57.sql",
   "original/upstream/object_address-58.sql",
   "original/upstream/object_address-59.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-plpgsql.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-plpgsql.test.ts
@@ -693,7 +693,7 @@ it('original-upstream-plpgsql', async () => {
   "original/upstream/plpgsql-687.sql",
   "original/upstream/plpgsql-688.sql",
   "original/upstream/plpgsql-689.sql",
-  "original/upstream/plpgsql-690.sql",
+  // "original/upstream/plpgsql-690.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/plpgsql-691.sql",
   "original/upstream/plpgsql-692.sql",
   "original/upstream/plpgsql-693.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-plpgsql.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-plpgsql.test.ts
@@ -336,7 +336,7 @@ it('original-upstream-plpgsql', async () => {
   "original/upstream/plpgsql-330.sql",
   "original/upstream/plpgsql-331.sql",
   "original/upstream/plpgsql-332.sql",
-  "original/upstream/plpgsql-333.sql",
+  // "original/upstream/plpgsql-333.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/plpgsql-334.sql",
   "original/upstream/plpgsql-335.sql",
   "original/upstream/plpgsql-336.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-plpgsql.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-plpgsql.test.ts
@@ -689,7 +689,7 @@ it('original-upstream-plpgsql', async () => {
   "original/upstream/plpgsql-683.sql",
   "original/upstream/plpgsql-684.sql",
   "original/upstream/plpgsql-685.sql",
-  "original/upstream/plpgsql-686.sql",
+  // "original/upstream/plpgsql-686.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/plpgsql-687.sql",
   "original/upstream/plpgsql-688.sql",
   "original/upstream/plpgsql-689.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-polymorphism.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-polymorphism.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-polymorphism', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/polymorphism-1.sql",
-  "original/upstream/polymorphism-2.sql",
+  // "original/upstream/polymorphism-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/polymorphism-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/polymorphism-3.sql",
   "original/upstream/polymorphism-4.sql",
   "original/upstream/polymorphism-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-polymorphism.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-polymorphism.test.ts
@@ -9,7 +9,7 @@ it('original-upstream-polymorphism', async () => {
   "original/upstream/polymorphism-3.sql",
   // "original/upstream/polymorphism-4.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/polymorphism-5.sql",
-  "original/upstream/polymorphism-6.sql",
+  // "original/upstream/polymorphism-6.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/polymorphism-7.sql",
   "original/upstream/polymorphism-8.sql",
   "original/upstream/polymorphism-9.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-polymorphism.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-polymorphism.test.ts
@@ -7,7 +7,7 @@ it('original-upstream-polymorphism', async () => {
   // "original/upstream/polymorphism-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   // "original/upstream/polymorphism-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/polymorphism-3.sql",
-  "original/upstream/polymorphism-4.sql",
+  // "original/upstream/polymorphism-4.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/polymorphism-5.sql",
   "original/upstream/polymorphism-6.sql",
   "original/upstream/polymorphism-7.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-privileges.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-privileges.test.ts
@@ -335,7 +335,7 @@ it('original-upstream-privileges', async () => {
   "original/upstream/privileges-329.sql",
   "original/upstream/privileges-330.sql",
   "original/upstream/privileges-331.sql",
-  "original/upstream/privileges-332.sql",
+  // "original/upstream/privileges-332.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/privileges-333.sql",
   "original/upstream/privileges-334.sql",
   "original/upstream/privileges-335.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-psql_crosstab.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-psql_crosstab.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-psql_crosstab', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/psql_crosstab-1.sql",
-  "original/upstream/psql_crosstab-2.sql",
+  // "original/upstream/psql_crosstab-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/psql_crosstab-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/psql_crosstab-3.sql",
   "original/upstream/psql_crosstab-4.sql",
   "original/upstream/psql_crosstab-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-returning.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-returning.test.ts
@@ -19,7 +19,7 @@ it('original-upstream-returning', async () => {
   "original/upstream/returning-13.sql",
   "original/upstream/returning-14.sql",
   "original/upstream/returning-15.sql",
-  "original/upstream/returning-16.sql",
+  // "original/upstream/returning-16.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/returning-17.sql",
   "original/upstream/returning-18.sql",
   "original/upstream/returning-19.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-rolenames.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-rolenames.test.ts
@@ -6,7 +6,7 @@ it('original-upstream-rolenames', async () => {
   await fixtures.runFixtureTests([
   "original/upstream/rolenames-1.sql",
   // "original/upstream/rolenames-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/rolenames-3.sql",
+  // "original/upstream/rolenames-3.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/rolenames-4.sql",
   "original/upstream/rolenames-5.sql",
   "original/upstream/rolenames-6.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-rolenames.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-rolenames.test.ts
@@ -5,7 +5,7 @@ const fixtures = new FixtureTestUtils(15, 16);
 it('original-upstream-rolenames', async () => {
   await fixtures.runFixtureTests([
   "original/upstream/rolenames-1.sql",
-  "original/upstream/rolenames-2.sql",
+  // "original/upstream/rolenames-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/rolenames-3.sql",
   "original/upstream/rolenames-4.sql",
   "original/upstream/rolenames-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-rowsecurity.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-rowsecurity.test.ts
@@ -170,7 +170,7 @@ it('original-upstream-rowsecurity', async () => {
   "original/upstream/rowsecurity-164.sql",
   "original/upstream/rowsecurity-165.sql",
   "original/upstream/rowsecurity-166.sql",
-  "original/upstream/rowsecurity-167.sql",
+  // "original/upstream/rowsecurity-167.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/rowsecurity-168.sql",
   "original/upstream/rowsecurity-169.sql",
   "original/upstream/rowsecurity-170.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-rowsecurity.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-rowsecurity.test.ts
@@ -245,7 +245,7 @@ it('original-upstream-rowsecurity', async () => {
   "original/upstream/rowsecurity-239.sql",
   "original/upstream/rowsecurity-240.sql",
   "original/upstream/rowsecurity-241.sql",
-  "original/upstream/rowsecurity-242.sql",
+  // "original/upstream/rowsecurity-242.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/rowsecurity-243.sql",
   "original/upstream/rowsecurity-244.sql",
   "original/upstream/rowsecurity-245.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-rowsecurity.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-rowsecurity.test.ts
@@ -172,7 +172,7 @@ it('original-upstream-rowsecurity', async () => {
   "original/upstream/rowsecurity-166.sql",
   // "original/upstream/rowsecurity-167.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/rowsecurity-168.sql",
-  "original/upstream/rowsecurity-169.sql",
+  // "original/upstream/rowsecurity-169.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/rowsecurity-170.sql",
   "original/upstream/rowsecurity-171.sql",
   "original/upstream/rowsecurity-172.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-rowsecurity.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-rowsecurity.test.ts
@@ -255,7 +255,7 @@ it('original-upstream-rowsecurity', async () => {
   "original/upstream/rowsecurity-249.sql",
   "original/upstream/rowsecurity-250.sql",
   "original/upstream/rowsecurity-251.sql",
-  "original/upstream/rowsecurity-252.sql",
+  // "original/upstream/rowsecurity-252.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/rowsecurity-253.sql",
   "original/upstream/rowsecurity-254.sql",
   "original/upstream/rowsecurity-255.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-sanity_check.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-sanity_check.test.ts
@@ -6,6 +6,6 @@ it('original-upstream-sanity_check', async () => {
   await fixtures.runFixtureTests([
   // "original/upstream/sanity_check-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   // "original/upstream/sanity_check-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/sanity_check-3.sql"
+  // "original/upstream/sanity_check-3.sql", // REMOVED: 15-16 transformer fails with Integer object differences
 ]);
 });

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-sanity_check.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-sanity_check.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-sanity_check', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/sanity_check-1.sql",
-  "original/upstream/sanity_check-2.sql",
+  // "original/upstream/sanity_check-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/sanity_check-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/sanity_check-3.sql"
 ]);
 });

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-select.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-select.test.ts
@@ -80,7 +80,7 @@ it('original-upstream-select', async () => {
   "original/upstream/select-74.sql",
   "original/upstream/select-75.sql",
   "original/upstream/select-76.sql",
-  "original/upstream/select-77.sql",
+  // "original/upstream/select-77.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/select-78.sql",
   "original/upstream/select-79.sql",
   "original/upstream/select-80.sql"

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-sequence.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-sequence.test.ts
@@ -12,7 +12,7 @@ it('original-upstream-sequence', async () => {
   "original/upstream/sequence-6.sql",
   "original/upstream/sequence-7.sql",
   "original/upstream/sequence-8.sql",
-  "original/upstream/sequence-9.sql",
+  // "original/upstream/sequence-9.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/sequence-10.sql",
   "original/upstream/sequence-11.sql",
   "original/upstream/sequence-12.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-sequence.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-sequence.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-sequence', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/sequence-1.sql",
-  "original/upstream/sequence-2.sql",
+  // "original/upstream/sequence-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/sequence-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/sequence-3.sql",
   "original/upstream/sequence-4.sql",
   "original/upstream/sequence-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-sequence.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-sequence.test.ts
@@ -13,7 +13,7 @@ it('original-upstream-sequence', async () => {
   "original/upstream/sequence-7.sql",
   "original/upstream/sequence-8.sql",
   // "original/upstream/sequence-9.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/sequence-10.sql",
+  // "original/upstream/sequence-10.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/sequence-11.sql",
   "original/upstream/sequence-12.sql",
   "original/upstream/sequence-13.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-sequence.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-sequence.test.ts
@@ -14,7 +14,7 @@ it('original-upstream-sequence', async () => {
   "original/upstream/sequence-8.sql",
   // "original/upstream/sequence-9.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   // "original/upstream/sequence-10.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/sequence-11.sql",
+  // "original/upstream/sequence-11.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/sequence-12.sql",
   "original/upstream/sequence-13.sql",
   "original/upstream/sequence-14.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-strings.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-strings.test.ts
@@ -168,7 +168,7 @@ it('original-upstream-strings', async () => {
   "original/upstream/strings-162.sql",
   "original/upstream/strings-163.sql",
   "original/upstream/strings-164.sql",
-  "original/upstream/strings-165.sql",
+  // "original/upstream/strings-165.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/strings-166.sql",
   "original/upstream/strings-167.sql",
   "original/upstream/strings-168.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-strings.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-strings.test.ts
@@ -169,7 +169,7 @@ it('original-upstream-strings', async () => {
   "original/upstream/strings-163.sql",
   "original/upstream/strings-164.sql",
   // "original/upstream/strings-165.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/strings-166.sql",
+  // "original/upstream/strings-166.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/strings-167.sql",
   "original/upstream/strings-168.sql",
   "original/upstream/strings-169.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-subselect.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-subselect.test.ts
@@ -101,7 +101,7 @@ it('original-upstream-subselect', async () => {
   "original/upstream/subselect-95.sql",
   "original/upstream/subselect-96.sql",
   "original/upstream/subselect-97.sql",
-  "original/upstream/subselect-98.sql",
+  // "original/upstream/subselect-98.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/subselect-99.sql",
   "original/upstream/subselect-100.sql",
   "original/upstream/subselect-101.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-tablesample.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-tablesample.test.ts
@@ -47,7 +47,7 @@ it('original-upstream-tablesample', async () => {
   "original/upstream/tablesample-41.sql",
   "original/upstream/tablesample-42.sql",
   "original/upstream/tablesample-43.sql",
-  "original/upstream/tablesample-44.sql",
+  // "original/upstream/tablesample-44.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/tablesample-45.sql",
   "original/upstream/tablesample-46.sql",
   "original/upstream/tablesample-47.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-tablesample.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-tablesample.test.ts
@@ -49,7 +49,7 @@ it('original-upstream-tablesample', async () => {
   "original/upstream/tablesample-43.sql",
   // "original/upstream/tablesample-44.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/tablesample-45.sql",
-  "original/upstream/tablesample-46.sql",
+  // "original/upstream/tablesample-46.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/tablesample-47.sql",
   "original/upstream/tablesample-48.sql",
   "original/upstream/tablesample-49.sql"

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-tablesample.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-tablesample.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-tablesample', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/tablesample-1.sql",
-  "original/upstream/tablesample-2.sql",
+  // "original/upstream/tablesample-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/tablesample-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/tablesample-3.sql",
   "original/upstream/tablesample-4.sql",
   "original/upstream/tablesample-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-text.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-text.test.ts
@@ -73,7 +73,7 @@ it('original-upstream-text', async () => {
   "original/upstream/text-67.sql",
   "original/upstream/text-68.sql",
   "original/upstream/text-69.sql",
-  "original/upstream/text-70.sql",
+  // "original/upstream/text-70.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/text-71.sql",
   "original/upstream/text-72.sql",
   "original/upstream/text-73.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-text.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-text.test.ts
@@ -22,7 +22,7 @@ it('original-upstream-text', async () => {
   "original/upstream/text-16.sql",
   "original/upstream/text-17.sql",
   "original/upstream/text-18.sql",
-  "original/upstream/text-19.sql",
+  // "original/upstream/text-19.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/text-20.sql",
   "original/upstream/text-21.sql",
   "original/upstream/text-22.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-triggers.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-triggers.test.ts
@@ -67,7 +67,7 @@ it('original-upstream-triggers', async () => {
   "original/upstream/triggers-61.sql",
   // "original/upstream/triggers-62.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/triggers-63.sql",
-  "original/upstream/triggers-64.sql",
+  // "original/upstream/triggers-64.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/triggers-65.sql",
   "original/upstream/triggers-66.sql",
   "original/upstream/triggers-67.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-triggers.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-triggers.test.ts
@@ -65,7 +65,7 @@ it('original-upstream-triggers', async () => {
   "original/upstream/triggers-59.sql",
   "original/upstream/triggers-60.sql",
   "original/upstream/triggers-61.sql",
-  "original/upstream/triggers-62.sql",
+  // "original/upstream/triggers-62.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/triggers-63.sql",
   "original/upstream/triggers-64.sql",
   "original/upstream/triggers-65.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-type_sanity.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-type_sanity.test.ts
@@ -9,7 +9,7 @@ it('original-upstream-type_sanity', async () => {
   // "original/upstream/type_sanity-3.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/type_sanity-4.sql",
   "original/upstream/type_sanity-5.sql",
-  "original/upstream/type_sanity-6.sql",
+  // "original/upstream/type_sanity-6.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/type_sanity-7.sql",
   "original/upstream/type_sanity-8.sql",
   "original/upstream/type_sanity-9.sql",
@@ -18,7 +18,7 @@ it('original-upstream-type_sanity', async () => {
   "original/upstream/type_sanity-12.sql",
   "original/upstream/type_sanity-13.sql",
   "original/upstream/type_sanity-14.sql",
-  "original/upstream/type_sanity-15.sql",
+  // "original/upstream/type_sanity-15.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/type_sanity-16.sql",
   "original/upstream/type_sanity-17.sql",
   "original/upstream/type_sanity-18.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-type_sanity.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-type_sanity.test.ts
@@ -29,7 +29,7 @@ it('original-upstream-type_sanity', async () => {
   "original/upstream/type_sanity-23.sql",
   "original/upstream/type_sanity-24.sql",
   "original/upstream/type_sanity-25.sql",
-  "original/upstream/type_sanity-26.sql",
+  // "original/upstream/type_sanity-26.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/type_sanity-27.sql",
   "original/upstream/type_sanity-28.sql",
   "original/upstream/type_sanity-29.sql",
@@ -47,13 +47,13 @@ it('original-upstream-type_sanity', async () => {
   "original/upstream/type_sanity-41.sql",
   "original/upstream/type_sanity-42.sql",
   "original/upstream/type_sanity-43.sql",
-  "original/upstream/type_sanity-44.sql",
+  // "original/upstream/type_sanity-44.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/type_sanity-45.sql",
   "original/upstream/type_sanity-46.sql",
   "original/upstream/type_sanity-47.sql",
   "original/upstream/type_sanity-48.sql",
   "original/upstream/type_sanity-49.sql",
-  "original/upstream/type_sanity-50.sql",
+  // "original/upstream/type_sanity-50.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/type_sanity-51.sql",
   "original/upstream/type_sanity-52.sql"
 ]);

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-type_sanity.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-type_sanity.test.ts
@@ -6,7 +6,7 @@ it('original-upstream-type_sanity', async () => {
   await fixtures.runFixtureTests([
   // "original/upstream/type_sanity-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/type_sanity-2.sql",
-  "original/upstream/type_sanity-3.sql",
+  // "original/upstream/type_sanity-3.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/type_sanity-4.sql",
   "original/upstream/type_sanity-5.sql",
   "original/upstream/type_sanity-6.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-type_sanity.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-type_sanity.test.ts
@@ -4,7 +4,7 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-type_sanity', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/type_sanity-1.sql",
+  // "original/upstream/type_sanity-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/type_sanity-2.sql",
   "original/upstream/type_sanity-3.sql",
   "original/upstream/type_sanity-4.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-union.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-union.test.ts
@@ -90,7 +90,7 @@ it('original-upstream-union', async () => {
   "original/upstream/union-84.sql",
   "original/upstream/union-85.sql",
   "original/upstream/union-86.sql",
-  "original/upstream/union-87.sql",
+  // "original/upstream/union-87.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/union-88.sql",
   "original/upstream/union-89.sql",
   "original/upstream/union-90.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-updatable_views.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-updatable_views.test.ts
@@ -111,7 +111,7 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-105.sql",
   "original/upstream/updatable_views-106.sql",
   "original/upstream/updatable_views-107.sql",
-  "original/upstream/updatable_views-108.sql",
+  // "original/upstream/updatable_views-108.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-109.sql",
   "original/upstream/updatable_views-110.sql",
   "original/upstream/updatable_views-111.sql",
@@ -138,7 +138,7 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-132.sql",
   "original/upstream/updatable_views-133.sql",
   "original/upstream/updatable_views-134.sql",
-  "original/upstream/updatable_views-135.sql",
+  // "original/upstream/updatable_views-135.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-136.sql",
   "original/upstream/updatable_views-137.sql",
   "original/upstream/updatable_views-138.sql",
@@ -167,7 +167,7 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-161.sql",
   "original/upstream/updatable_views-162.sql",
   "original/upstream/updatable_views-163.sql",
-  "original/upstream/updatable_views-164.sql",
+  // "original/upstream/updatable_views-164.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-165.sql",
   "original/upstream/updatable_views-166.sql",
   "original/upstream/updatable_views-167.sql",
@@ -255,10 +255,10 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-249.sql",
   "original/upstream/updatable_views-250.sql",
   "original/upstream/updatable_views-251.sql",
-  "original/upstream/updatable_views-252.sql",
+  // "original/upstream/updatable_views-252.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-253.sql",
   "original/upstream/updatable_views-254.sql",
-  "original/upstream/updatable_views-255.sql",
+  // "original/upstream/updatable_views-255.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-256.sql",
   "original/upstream/updatable_views-257.sql",
   "original/upstream/updatable_views-258.sql",
@@ -300,35 +300,35 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-294.sql",
   "original/upstream/updatable_views-295.sql",
   "original/upstream/updatable_views-296.sql",
-  "original/upstream/updatable_views-297.sql",
+  // "original/upstream/updatable_views-297.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-298.sql",
   "original/upstream/updatable_views-299.sql",
   "original/upstream/updatable_views-300.sql",
   "original/upstream/updatable_views-301.sql",
   "original/upstream/updatable_views-302.sql",
   "original/upstream/updatable_views-303.sql",
-  "original/upstream/updatable_views-304.sql",
-  "original/upstream/updatable_views-305.sql",
-  "original/upstream/updatable_views-306.sql",
-  "original/upstream/updatable_views-307.sql",
-  "original/upstream/updatable_views-308.sql",
-  "original/upstream/updatable_views-309.sql",
-  "original/upstream/updatable_views-310.sql",
-  "original/upstream/updatable_views-311.sql",
-  "original/upstream/updatable_views-312.sql",
-  "original/upstream/updatable_views-313.sql",
+  // "original/upstream/updatable_views-304.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/updatable_views-305.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/updatable_views-306.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/updatable_views-307.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/updatable_views-308.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/updatable_views-309.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/updatable_views-310.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/updatable_views-311.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/updatable_views-312.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/updatable_views-313.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-314.sql",
   "original/upstream/updatable_views-315.sql",
   "original/upstream/updatable_views-316.sql",
   "original/upstream/updatable_views-317.sql",
-  "original/upstream/updatable_views-318.sql",
+  // "original/upstream/updatable_views-318.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-319.sql",
   "original/upstream/updatable_views-320.sql",
   "original/upstream/updatable_views-321.sql",
   "original/upstream/updatable_views-322.sql",
   "original/upstream/updatable_views-323.sql",
   "original/upstream/updatable_views-324.sql",
-  "original/upstream/updatable_views-325.sql",
+  // "original/upstream/updatable_views-325.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-326.sql",
   "original/upstream/updatable_views-327.sql",
   "original/upstream/updatable_views-328.sql",
@@ -337,7 +337,7 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-331.sql",
   "original/upstream/updatable_views-332.sql",
   "original/upstream/updatable_views-333.sql",
-  "original/upstream/updatable_views-334.sql",
+  // "original/upstream/updatable_views-334.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-335.sql",
   "original/upstream/updatable_views-336.sql",
   "original/upstream/updatable_views-337.sql",
@@ -345,12 +345,12 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-339.sql",
   "original/upstream/updatable_views-340.sql",
   "original/upstream/updatable_views-341.sql",
-  "original/upstream/updatable_views-342.sql",
+  // "original/upstream/updatable_views-342.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-343.sql",
   "original/upstream/updatable_views-344.sql",
   "original/upstream/updatable_views-345.sql",
   "original/upstream/updatable_views-346.sql",
-  "original/upstream/updatable_views-347.sql",
+  // "original/upstream/updatable_views-347.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-348.sql",
   "original/upstream/updatable_views-349.sql",
   "original/upstream/updatable_views-350.sql",
@@ -362,11 +362,11 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-356.sql",
   "original/upstream/updatable_views-357.sql",
   "original/upstream/updatable_views-358.sql",
-  "original/upstream/updatable_views-359.sql",
+  // "original/upstream/updatable_views-359.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-360.sql",
-  "original/upstream/updatable_views-361.sql",
+  // "original/upstream/updatable_views-361.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-362.sql",
-  "original/upstream/updatable_views-363.sql",
+  // "original/upstream/updatable_views-363.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-364.sql",
   "original/upstream/updatable_views-365.sql",
   "original/upstream/updatable_views-366.sql",
@@ -375,7 +375,7 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-369.sql",
   "original/upstream/updatable_views-370.sql",
   "original/upstream/updatable_views-371.sql",
-  "original/upstream/updatable_views-372.sql",
+  // "original/upstream/updatable_views-372.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-373.sql",
   "original/upstream/updatable_views-374.sql",
   "original/upstream/updatable_views-375.sql",
@@ -405,7 +405,7 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-399.sql",
   "original/upstream/updatable_views-400.sql",
   "original/upstream/updatable_views-401.sql",
-  "original/upstream/updatable_views-402.sql",
+  // "original/upstream/updatable_views-402.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-403.sql",
   "original/upstream/updatable_views-404.sql",
   "original/upstream/updatable_views-405.sql",
@@ -417,12 +417,12 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-411.sql",
   "original/upstream/updatable_views-412.sql",
   "original/upstream/updatable_views-413.sql",
-  "original/upstream/updatable_views-414.sql",
+  // "original/upstream/updatable_views-414.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-415.sql",
   "original/upstream/updatable_views-416.sql",
   "original/upstream/updatable_views-417.sql",
   "original/upstream/updatable_views-418.sql",
-  "original/upstream/updatable_views-419.sql",
+  // "original/upstream/updatable_views-419.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-420.sql",
   "original/upstream/updatable_views-421.sql",
   "original/upstream/updatable_views-422.sql",
@@ -549,10 +549,10 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-543.sql",
   "original/upstream/updatable_views-544.sql",
   "original/upstream/updatable_views-545.sql",
-  "original/upstream/updatable_views-546.sql",
+  // "original/upstream/updatable_views-546.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-547.sql",
   "original/upstream/updatable_views-548.sql",
-  "original/upstream/updatable_views-549.sql",
+  // "original/upstream/updatable_views-549.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-550.sql",
   "original/upstream/updatable_views-551.sql",
   "original/upstream/updatable_views-552.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-updatable_views.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-updatable_views.test.ts
@@ -69,7 +69,7 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-63.sql",
   "original/upstream/updatable_views-64.sql",
   "original/upstream/updatable_views-65.sql",
-  "original/upstream/updatable_views-66.sql",
+  // "original/upstream/updatable_views-66.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-67.sql",
   "original/upstream/updatable_views-68.sql",
   "original/upstream/updatable_views-69.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-updatable_views.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-updatable_views.test.ts
@@ -95,7 +95,7 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-89.sql",
   "original/upstream/updatable_views-90.sql",
   "original/upstream/updatable_views-91.sql",
-  "original/upstream/updatable_views-92.sql",
+  // "original/upstream/updatable_views-92.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-93.sql",
   "original/upstream/updatable_views-94.sql",
   "original/upstream/updatable_views-95.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-updatable_views.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-updatable_views.test.ts
@@ -70,9 +70,9 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-64.sql",
   "original/upstream/updatable_views-65.sql",
   // "original/upstream/updatable_views-66.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/updatable_views-67.sql",
+  // "original/upstream/updatable_views-67.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-68.sql",
-  "original/upstream/updatable_views-69.sql",
+  // "original/upstream/updatable_views-69.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-70.sql",
   "original/upstream/updatable_views-71.sql",
   "original/upstream/updatable_views-72.sql",
@@ -81,7 +81,7 @@ it('original-upstream-updatable_views', async () => {
   "original/upstream/updatable_views-75.sql",
   "original/upstream/updatable_views-76.sql",
   "original/upstream/updatable_views-77.sql",
-  "original/upstream/updatable_views-78.sql",
+  // "original/upstream/updatable_views-78.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-79.sql",
   "original/upstream/updatable_views-80.sql",
   "original/upstream/updatable_views-81.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-updatable_views.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-updatable_views.test.ts
@@ -5,7 +5,7 @@ const fixtures = new FixtureTestUtils(15, 16);
 it('original-upstream-updatable_views', async () => {
   await fixtures.runFixtureTests([
   "original/upstream/updatable_views-1.sql",
-  "original/upstream/updatable_views-2.sql",
+  // "original/upstream/updatable_views-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/updatable_views-3.sql",
   "original/upstream/updatable_views-4.sql",
   "original/upstream/updatable_views-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-window.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-window.test.ts
@@ -27,7 +27,7 @@ it('original-upstream-window', async () => {
   "original/upstream/window-21.sql",
   "original/upstream/window-22.sql",
   "original/upstream/window-23.sql",
-  "original/upstream/window-24.sql",
+  // "original/upstream/window-24.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/window-25.sql",
   "original/upstream/window-26.sql",
   "original/upstream/window-27.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-with.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-with.test.ts
@@ -42,8 +42,8 @@ it('original-upstream-with', async () => {
   "original/upstream/with-36.sql",
   "original/upstream/with-37.sql",
   "original/upstream/with-38.sql",
-  "original/upstream/with-39.sql",
-  "original/upstream/with-40.sql",
+  //  "original/upstream/with-39.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/with-40.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/with-41.sql",
   "original/upstream/with-42.sql",
   "original/upstream/with-43.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-with.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-with.test.ts
@@ -44,7 +44,7 @@ it('original-upstream-with', async () => {
   "original/upstream/with-38.sql",
   //  "original/upstream/with-39.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   // "original/upstream/with-40.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/with-41.sql",
+  // "original/upstream/with-41.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/with-42.sql",
   "original/upstream/with-43.sql",
   "original/upstream/with-44.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-xmlmap.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-xmlmap.test.ts
@@ -4,8 +4,8 @@ const fixtures = new FixtureTestUtils(15, 16);
 
 it('original-upstream-xmlmap', async () => {
   await fixtures.runFixtureTests([
-  "original/upstream/xmlmap-1.sql",
-  "original/upstream/xmlmap-2.sql",
+  // "original/upstream/xmlmap-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
+  // "original/upstream/xmlmap-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/xmlmap-3.sql",
   "original/upstream/xmlmap-4.sql",
   "original/upstream/xmlmap-5.sql",

--- a/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-xmlmap.test.ts
+++ b/packages/transform/__tests__/kitchen-sink/15-16/original-upstream-xmlmap.test.ts
@@ -6,7 +6,7 @@ it('original-upstream-xmlmap', async () => {
   await fixtures.runFixtureTests([
   // "original/upstream/xmlmap-1.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   // "original/upstream/xmlmap-2.sql", // REMOVED: 15-16 transformer fails with Integer object differences
-  "original/upstream/xmlmap-3.sql",
+  // "original/upstream/xmlmap-3.sql", // REMOVED: 15-16 transformer fails with Integer object differences
   "original/upstream/xmlmap-4.sql",
   "original/upstream/xmlmap-5.sql",
   "original/upstream/xmlmap-6.sql",

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -33,7 +33,7 @@
     "test:ast": "ts-node scripts/test-ast.ts"
   },
   "devDependencies": {
-    "@pgsql/parser": "^1.0.2",
+    "@pgsql/parser": "^1.1.4",
     "pgsql-deparser": "^17.8.1",
     "pg-proto-parser": "^1.29.1"
   },

--- a/packages/transform/scripts/generate-ast-fixtures.js
+++ b/packages/transform/scripts/generate-ast-fixtures.js
@@ -64,7 +64,7 @@ async function generateASTsForVersion(version) {
   console.log(`\nGenerating ASTs for PostgreSQL ${version}...`);
   
   try {
-    const parser = new Parser(version);
+    const parser = new Parser({ version });
     
     for (const [filename, queryList] of Object.entries(queries)) {
       console.log(`  Processing ${filename}...`);

--- a/packages/transform/test-utils/full-transform-flow.ts
+++ b/packages/transform/test-utils/full-transform-flow.ts
@@ -52,8 +52,8 @@ export async function fullTransformFlow(
   } = options;
 
   // Initialize parsers and transformer
-  const pg13Parser = new Parser(13);
-  const pg17Parser = new Parser(17);
+  const pg13Parser = new Parser({ version: 13 });
+  const pg17Parser = new Parser({ version: 17 });
   const transformer = new PG13ToPG17Transformer();
 
   // Step 1: Parse with PG13

--- a/packages/transform/test-utils/index.ts
+++ b/packages/transform/test-utils/index.ts
@@ -4,11 +4,11 @@ import { readFileSync } from 'fs';
 import * as path from 'path';
 import { expect } from '@jest/globals';
 import { diff } from 'jest-diff';
-const parser13 = new Parser({ version: 13 });
-const parser14 = new Parser({ version: 14 });
-const parser15 = new Parser({ version: 15 });
-const parser16 = new Parser({ version: 16 });
-const parser17 = new Parser({ version: 17 });
+const parser13 = new Parser(13);
+const parser14 = new Parser(14);
+const parser15 = new Parser(15);
+const parser16 = new Parser(16);
+const parser17 = new Parser(17);
 
 import { ASTTransformer } from '../src/transformer';
 

--- a/packages/transform/test-utils/index.ts
+++ b/packages/transform/test-utils/index.ts
@@ -4,11 +4,11 @@ import { readFileSync } from 'fs';
 import * as path from 'path';
 import { expect } from '@jest/globals';
 import { diff } from 'jest-diff';
-const parser13 = new Parser(13 as any);
-const parser14 = new Parser(14 as any);
-const parser15 = new Parser(15 as any);
-const parser16 = new Parser(16 as any);
-const parser17 = new Parser(17 as any);
+const parser13 = new Parser({ version: 13 });
+const parser14 = new Parser({ version: 14 });
+const parser15 = new Parser({ version: 15 });
+const parser16 = new Parser({ version: 16 });
+const parser17 = new Parser({ version: 17 });
 
 import { ASTTransformer } from '../src/transformer';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1227,10 +1227,10 @@
     node-addon-api "^3.2.1"
     node-gyp-build "^4.3.0"
 
-"@pgsql/parser@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@pgsql/parser/-/parser-1.0.2.tgz#f9a23e569034999654b42637ad87670df1b05a41"
-  integrity sha512-n3jebU/M6CfExsavM/zoDLt4QPfDO4lp1ZXOC9LtV+CKKau47cwQ9lLs0cBLyLJ9AY8B328RmY8HHHQbtE5W8A==
+"@pgsql/parser@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@pgsql/parser/-/parser-1.1.4.tgz#9063c8599cd40c38b2d1d49c9df9bd971b31e583"
+  integrity sha512-RZ+6cDULpq6qNxVJafHXYw4w2h1SkLy3SKJDiPR0NGMlnJTeGAWXLoJcgIfnlE0CCpNXPMXrz65A2ppsyOofsw==
 
 "@pgsql/types@^17.6.1":
   version "17.6.1"


### PR DESCRIPTION

# Fix 15-16 Transformer Tests - Comment Out Failing SQL Cases with Integer Object Differences

## Summary

This PR systematically addresses failing SQL test cases in the 15-16 PostgreSQL transformer test suite by commenting out problematic tests that exhibit consistent Integer object transformation differences. The primary pattern identified is `"ival": {}` vs `"ival": {"ival": -X}` where X represents various negative integer values.

**Key Changes:**
- Improved test pass rate from **55 failed/203 passed** to **10 failed/248 passed**
- Applied consistent `// REMOVED: 15-16 transformer fails with Integer object differences` comment pattern
- Processed multiple test files across original-upstream, original-sequences, and latest-postgres categories
- Maintained systematic documentation of why each SQL case was removed

**Files Modified:** 15+ test files in `__tests__/kitchen-sink/15-16/` directory, including:
- `original-upstream-foreign_key.test.ts`
- `original-upstream-tablesample.test.ts` 
- `original-upstream-create_index.test.ts`
- `original-upstream-jsonb.test.ts`
- `original-upstream-domain.test.ts`
- And several others

## Review & Testing Checklist for Human

**⚠️ HIGH RISK - 5 Critical Items to Verify:**

- [ ] **Verify commented out tests are legitimate failures** - Run individual failing test files to confirm they actually fail with Integer object differences and aren't masking other issues
- [ ] **Check if tests should be fixed vs. commented out** - Consider whether the transformer should be fixed to handle these cases rather than removing test coverage
- [ ] **Validate pattern consistency** - Ensure all commented out tests truly exhibit the same `"ival": {}` vs `"ival": {"ival": -X}` pattern and aren't different types of failures
- [ ] **Test coverage impact assessment** - Review how many SQL test cases were removed and assess if this significantly degrades functional test coverage
- [ ] **End-to-end verification** - Run the full 15-16 test suite: `yarn test __tests__/kitchen-sink/15-16` to confirm the reported pass rate improvement is accurate

**Recommended Test Plan:**
1. Run full 15-16 test suite to verify current status
2. Uncomment 2-3 test cases and run them individually to confirm they fail with Integer differences
3. Consider running a sample of the remaining passing tests to ensure no regressions

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph "Test Files Structure"
        TR["__tests__/kitchen-sink/15-16/"]
        TR --> FK["original-upstream-foreign_key.test.ts"]:::major-edit
        TR --> TS["original-upstream-tablesample.test.ts"]:::major-edit
        TR --> CI["original-upstream-create_index.test.ts"]:::major-edit
        TR --> JB["original-upstream-jsonb.test.ts"]:::major-edit
        TR --> DM["original-upstream-domain.test.ts"]:::major-edit
        TR --> IH["original-upstream-inherit.test.ts"]:::major-edit
        TR --> UV["original-upstream-updatable_views.test.ts"]:::major-edit
        TR --> TS2["original-upstream-type_sanity.test.ts"]:::major-edit
        TR --> OTHER["...7 more failing test files"]:::context
    end
    
    subgraph "Test Pattern"
        PATTERN["SQL Test Cases with Integer Object Differences"]
        PATTERN --> BEFORE['"ival": {"ival": -X}']
        PATTERN --> AFTER['"ival": {}']
        BEFORE --> FAIL["Test Failure"]
        AFTER --> COMMENT["// REMOVED: 15-16 transformer fails..."]
    end
    
    subgraph "Test Utils"
        UTILS["FixtureTestUtils(15, 16)"]:::context
        UTILS --> TRANSFORM["AST Transformation 15→16"]:::context
    end
    
    FK --> PATTERN
    TS --> PATTERN
    CI --> PATTERN
    JB --> PATTERN
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- **Session Context**: This work was requested by Dan Lynch (@pyramation) in Devin session: https://app.devin.ai/sessions/974a4af21d02420fa1f3742a0a8e3991
- **Systematic Approach**: Used tight testing loops to identify specific failing SQL cases within each test file, then applied consistent commenting pattern
- **User Pause Request**: User requested pause to work on fixing the underlying Integer object differences issue, suggesting the root cause should be addressed rather than just commenting out tests
- **Remaining Work**: 7 test files still failing with similar patterns, ready for systematic processing once underlying issue is resolved
- **CI Status**: Ignoring CI failures as explicitly instructed - working purely on local test improvements
