### PR TITLE
[proposal] specify license directly in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/launchql/pgsql-parser"
   },
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "publishConfig": {
     "access": "restricted"
   },

--- a/packages/deparser/package.json
+++ b/packages/deparser/package.json
@@ -7,7 +7,7 @@
   "module": "esm/index.js",
   "types": "index.d.ts",
   "homepage": "https://github.com/launchql/pgsql-parser",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "publishConfig": {
     "access": "public",
     "directory": "dist"

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -7,7 +7,7 @@
   "module": "esm/index.js",
   "types": "index.d.ts",
   "homepage": "https://github.com/launchql/pgsql-parser",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "publishConfig": {
     "access": "public",
     "directory": "dist"

--- a/packages/pgsql-cli/package.json
+++ b/packages/pgsql-cli/package.json
@@ -7,7 +7,7 @@
   "module": "esm/index.js",
   "types": "index.d.ts",
   "homepage": "https://github.com/launchql/pgsql-parser/tree/master/packages/pgsql-cli#readme",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/proto-parser/package.json
+++ b/packages/proto-parser/package.json
@@ -7,7 +7,7 @@
   "module": "esm/index.js",
   "types": "index.d.ts",
   "homepage": "https://github.com/launchql/pgsql-parser/tree/master/packages/proto-parser#readme",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "publishConfig": {
     "access": "public",
     "directory": "dist"

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -7,7 +7,7 @@
   "module": "esm/index.js",
   "types": "index.d.ts",
   "homepage": "https://github.com/launchql/pgsql-parser",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "publishConfig": {
     "access": "public",
     "directory": "dist"

--- a/packages/traverse/package.json
+++ b/packages/traverse/package.json
@@ -7,7 +7,7 @@
   "module": "esm/index.js",
   "types": "index.d.ts",
   "homepage": "https://github.com/launchql/pgsql-parser",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "publishConfig": {
     "access": "public",
     "directory": "dist"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,7 +7,7 @@
   "module": "esm/index.js",
   "types": "index.d.ts",
   "homepage": "https://github.com/launchql/pgsql-parser",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "publishConfig": {
     "access": "public",
     "directory": "dist"


### PR DESCRIPTION
Hi - really appreciate this package. I was wondering if you'd be open to specifying the package licenses directly in the package.json in addition to the LICENSE file. The reason being that we use the [dependency review GitHub action](https://github.com/actions/dependency-review-action) and its `allowed-licenses` check gets confused by the "SEE LICENSE IN LICENSE" value. We can add exclusions for specific packages, but specifying the license in package.json should allow it to work out-of-the-box with this check.