### PR TITLE
Fix issue #219: Add support for OBJECT_PUBLICATION in AlterOwnerStmt

### DIFF
--- a/__fixtures__/generated/generated.json
+++ b/__fixtures__/generated/generated.json
@@ -21285,6 +21285,7 @@
   "misc/issues-14.sql": "SELECT (1 IS NOT NULL) IS DISTINCT FROM (2 IS NOT NULL)",
   "misc/issues-15.sql": "select \"A\" from \"table_name\"",
   "misc/issues-16.sql": "select \"AA\" from \"table_name\"",
+  "misc/issues-17.sql": "ALTER PUBLICATION \"my_publication\" OWNER TO \"postgres\"",
   "misc/inflection-1.sql": "CREATE SCHEMA inflection",
   "misc/inflection-2.sql": "GRANT USAGE ON SCHEMA inflection TO PUBLIC",
   "misc/inflection-3.sql": "ALTER DEFAULT PRIVILEGES IN SCHEMA inflection \n GRANT EXECUTE ON FUNCTIONS  TO PUBLIC",

--- a/__fixtures__/kitchen-sink/misc/issues.sql
+++ b/__fixtures__/kitchen-sink/misc/issues.sql
@@ -72,3 +72,6 @@ SELECT (1 IS NOT NULL) IS DISTINCT FROM (2 IS NOT NULL);
 -- https://github.com/launchql/pgsql-parser/issues/101
 select "A" from "table_name";
 select "AA" from "table_name";
+
+-- https://github.com/launchql/pgsql-parser/issues/219
+ALTER PUBLICATION "my_publication" OWNER TO "postgres";

--- a/packages/deparser/__tests__/kitchen-sink/misc-issues.test.ts
+++ b/packages/deparser/__tests__/kitchen-sink/misc-issues.test.ts
@@ -19,6 +19,7 @@ it('misc-issues', async () => {
   "misc/issues-13.sql",
   "misc/issues-14.sql",
   "misc/issues-15.sql",
-  "misc/issues-16.sql"
+  "misc/issues-16.sql",
+  "misc/issues-17.sql"
 ]);
 });

--- a/packages/deparser/src/deparser.ts
+++ b/packages/deparser/src/deparser.ts
@@ -8286,6 +8286,9 @@ export class Deparser implements DeparserVisitor {
       case 'OBJECT_COLLATION':
         output.push('COLLATION');
         break;
+      case 'OBJECT_PUBLICATION':
+        output.push('PUBLICATION');
+        break;
       default:
         throw new Error(`Unsupported AlterOwnerStmt objectType: ${node.objectType}`);
     }


### PR DESCRIPTION
# Fix #219: Add OBJECT_PUBLICATION support to AlterOwnerStmt deparser

## Summary
Adds support for deparsing `ALTER PUBLICATION ... OWNER TO ...` statements by adding the `OBJECT_PUBLICATION` case to the `AlterOwnerStmt` switch statement in the deparser.

**Changes:**
- Added `OBJECT_PUBLICATION` case in `packages/deparser/src/deparser.ts` (3 lines)
- Fixture test for issue #219 was already added in the base branch `fix/issues-219`

**Before:** Deparser threw error: `Unsupported AlterOwnerStmt objectType: OBJECT_PUBLICATION`  
**After:** Successfully deparses to: `ALTER PUBLICATION "my_publication" OWNER TO "postgres"`

## Review & Testing Checklist for Human
- [ ] Verify the fixture test `misc/issues-17.sql` passes and correctly round-trips the SQL statement
- [ ] Confirm CI checks pass (especially deparser test suite - all 284 tests should pass)
- [ ] Spot-check that the change follows the same pattern as other object types (e.g., `OBJECT_COLLATION`, `OBJECT_TYPE`)

### Notes
- This is a minimal, surgical fix that adds 3 lines following the exact same pattern as all other object types in the switch statement
- All 284 deparser tests pass locally
- No new lint issues introduced by this change
- Built on top of the `fix/issues-219` branch which already included the fixture test

**Link to Devin run:** https://app.devin.ai/sessions/505114984e764debaca3c75b2dab458c  
**Requested by:** Dan Lynch (pyramation@gmail.com) / @pyramation