### PR TITLE
Fix walk function to traverse WithClause and union larg/rarg nodes

### DIFF
--- a/packages/traverse/scripts/pg-proto-parser.ts
+++ b/packages/traverse/scripts/pg-proto-parser.ts
@@ -1,5 +1,5 @@
+import { join,resolve } from 'path';
 import { PgProtoParser, PgProtoParserOptions } from 'pg-proto-parser';
-import { resolve, join } from 'path';
 
 const versions = ['17'];
 const baseDir = resolve(join(__dirname, '../../../__fixtures__/proto'));

--- a/packages/traverse/src/index.ts
+++ b/packages/traverse/src/index.ts
@@ -1,2 +1,2 @@
-export { walk, visit, NodePath } from './traverse';
-export type { Visitor, VisitorContext, Walker, NodeTag } from './traverse';
+export type { NodeTag,Visitor, VisitorContext, Walker } from './traverse';
+export { NodePath,visit, walk } from './traverse';

--- a/packages/traverse/src/traverse.ts
+++ b/packages/traverse/src/traverse.ts
@@ -1,5 +1,6 @@
 
 import type { Node } from '@pgsql/types';
+
 import type { NodeSpec } from './17/runtime-schema';
 import { runtimeSchema } from './17/runtime-schema';
 
@@ -47,10 +48,10 @@ export function walk(
   const actualCallback: Walker = typeof callback === 'function' 
     ? callback 
     : (path: NodePath) => {
-        const visitor = callback as Visitor;
-        const visitFn = visitor[path.tag];
-        return visitFn ? visitFn(path) : undefined;
-      };
+      const visitor = callback as Visitor;
+      const visitFn = visitor[path.tag];
+      return visitFn ? visitFn(path) : undefined;
+    };
 
   if (Array.isArray(root)) {
     root.forEach((node, index) => {
@@ -70,7 +71,9 @@ export function walk(
       const nodeSpec = schemaMap.get(tag);
       if (nodeSpec) {
         for (const field of nodeSpec.fields) {
-          if (field.type === 'Node' && nodeData[field.name] != null) {
+          // Check if field type is 'Node' or any other node type (e.g., 'WithClause', 'SelectStmt', etc.)
+          const isNodeType = field.type === 'Node' || schemaMap.has(field.type);
+          if (isNodeType && nodeData[field.name] != null) {
             const value = nodeData[field.name];
             if (field.isArray && Array.isArray(value)) {
               value.forEach((item, index) => {


### PR DESCRIPTION
# Fix walk function to traverse WithClause and union larg/rarg nodes

## Summary
Fixes #216 by updating the `walk` function in the traverse package to properly handle fields with specific node types (like `WithClause`, `SelectStmt`) instead of only traversing fields explicitly marked as type `'Node'`.

**The Problem:** The walk function was only traversing fields where `field.type === 'Node'`, but some fields in the runtime schema have specific types like `'WithClause'` or `'SelectStmt'`. This caused the traversal to skip:
- `withClause` fields (type: `'WithClause'`)
- `larg` and `rarg` fields in union operations (type: `'SelectStmt'`)

**The Solution:** Modified the traversal logic to check if a field's type exists in the `schemaMap` (meaning it's a valid node type), not just if it's explicitly `'Node'`. This allows traversal of all 268 node types defined in the schema.

**Changes:**
- Updated `packages/traverse/src/traverse.ts` to check `schemaMap.has(field.type)` in addition to `field.type === 'Node'`
- Added test case for WithClause traversal
- Added test case for union larg/rarg traversal
- Minor auto-formatting changes from ESLint (import ordering, indentation)

## Review & Testing Checklist for Human
- [ ] **Test with real SQL queries**: Verify the fix works with actual SQL containing WITH clauses (CTEs) and UNION operations. Parse a query, walk the AST, and confirm all nodes are visited.
- [ ] **Verify scope of change**: This change affects traversal of ALL node types in the schema (268 types), not just WithClause and SelectStmt. Review if this broader behavior is correct and doesn't cause unintended side effects.
- [ ] **Check test coverage**: Review the two new test cases to ensure they adequately demonstrate the fix. Consider if additional test cases are needed for other previously-skipped node types.

### Test Plan
```typescript
import { parse } from 'pgsql-parser';
import { walk } from '@pgsql/traverse';

// Test WITH clause
const withQuery = 'WITH cte AS (SELECT 1) SELECT * FROM cte';
const withAst = parse(withQuery);
const withNodes: string[] = [];
walk(withAst, (path) => { withNodes.push(path.tag); });
console.log('WITH clause nodes:', withNodes);
// Should include: SelectStmt, WithClause, CommonTableExpr, SelectStmt (nested)

// Test UNION
const unionQuery = 'SELECT 1 UNION SELECT 2';
const unionAst = parse(unionQuery);
const unionNodes: string[] = [];
walk(unionAst, (path) => { unionNodes.push(path.tag); });
console.log('UNION nodes:', unionNodes);
// Should include: SelectStmt (parent), SelectStmt (larg), SelectStmt (rarg)
```

### Notes
- All existing tests pass, including the two new test cases
- ESLint auto-formatting made minor cosmetic changes (import ordering, indentation)
- Session: https://app.devin.ai/sessions/2dcc9bb6a9504b4080fdef934deaf4d3
- Requested by: Dan Lynch (@pyramation)