### PR TITLE
Fix walk function to traverse WithClause and union larg/rarg nodes

### DIFF
--- a/packages/traverse/scripts/pg-proto-parser.ts
+++ b/packages/traverse/scripts/pg-proto-parser.ts
@@ -1,5 +1,5 @@
+import { join,resolve } from 'path';
 import { PgProtoParser, PgProtoParserOptions } from 'pg-proto-parser';
-import { resolve, join } from 'path';
 
 const versions = ['17'];
 const baseDir = resolve(join(__dirname, '../../../__fixtures__/proto'));

--- a/packages/traverse/src/index.ts
+++ b/packages/traverse/src/index.ts
@@ -1,2 +1,2 @@
-export { walk, visit, NodePath } from './traverse';
-export type { Visitor, VisitorContext, Walker, NodeTag } from './traverse';
+export type { NodeTag,Visitor, VisitorContext, Walker } from './traverse';
+export { NodePath,visit, walk } from './traverse';

--- a/packages/traverse/src/traverse.ts
+++ b/packages/traverse/src/traverse.ts
@@ -1,5 +1,6 @@
 
 import type { Node } from '@pgsql/types';
+
 import type { NodeSpec } from './17/runtime-schema';
 import { runtimeSchema } from './17/runtime-schema';
 
@@ -47,10 +48,10 @@ export function walk(
   const actualCallback: Walker = typeof callback === 'function' 
     ? callback 
     : (path: NodePath) => {
-        const visitor = callback as Visitor;
-        const visitFn = visitor[path.tag];
-        return visitFn ? visitFn(path) : undefined;
-      };
+      const visitor = callback as Visitor;
+      const visitFn = visitor[path.tag];
+      return visitFn ? visitFn(path) : undefined;
+    };
 
   if (Array.isArray(root)) {
     root.forEach((node, index) => {
@@ -70,7 +71,9 @@ export function walk(
       const nodeSpec = schemaMap.get(tag);
       if (nodeSpec) {
         for (const field of nodeSpec.fields) {
-          if (field.type === 'Node' && nodeData[field.name] != null) {
+          // Check if field type is 'Node' or any other node type (e.g., 'WithClause', 'SelectStmt', etc.)
+          const isNodeType = field.type === 'Node' || schemaMap.has(field.type);
+          if (isNodeType && nodeData[field.name] != null) {
             const value = nodeData[field.name];
             if (field.isArray && Array.isArray(value)) {
               value.forEach((item, index) => {


### PR DESCRIPTION
- Modified walk function to check if field type is any node type (not just 'Node')
- Added logic to use schemaMap to determine if a field type is a node
- Added test cases for WithClause traversal
- Added test cases for union larg/rarg traversal
- Fixes #216