### PR TITLE
Add CREATE FOREIGN TABLE fixture with schema-qualified column type

### DIFF
--- a/__fixtures__/generated/generated.json
+++ b/__fixtures__/generated/generated.json
@@ -20888,6 +20888,7 @@
   "original/tables/match-4.sql": "CREATE TABLE post_type (\n  id integer NOT NULL PRIMARY KEY\n)",
   "original/tables/match-5.sql": "DROP TABLE IF EXISTS assembly_seat CASCADE",
   "original/tables/match-6.sql": "CREATE TABLE assembly_seat (\n  id integer NOT NULL PRIMARY KEY\n)",
+  "original/tables/foreign_table-1.sql": "CREATE FOREIGN TABLE public.foo (\n bar pg_catalog.varchar(50) \n) SERVER dummy OPTIONS (schema_name 'public', table_name 'foo')",
   "original/tables/foreign-1.sql": "CREATE TABLE orders (\n    order_id integer PRIMARY KEY,\n    product_no integer REFERENCES products (product_no),\n    quantity integer\n)",
   "original/tables/foreign-2.sql": "CREATE TABLE orders (\n    order_id integer PRIMARY KEY,\n    product_no integer REFERENCES products,\n    quantity integer\n)",
   "original/tables/foreign-3.sql": "CREATE TABLE t1 (\n  a integer PRIMARY KEY,\n  b integer,\n  c integer,\n  FOREIGN KEY (b, c) REFERENCES other_table (c1, c2)\n)",

--- a/__fixtures__/kitchen-sink/original/tables/foreign_table.sql
+++ b/__fixtures__/kitchen-sink/original/tables/foreign_table.sql
@@ -1,0 +1,4 @@
+-- CREATE FOREIGN TABLE with schema-qualified column type and FDW options
+CREATE FOREIGN TABLE public.foo (
+ bar pg_catalog.varchar(50) 
+) SERVER dummy OPTIONS (schema_name 'public', table_name 'foo');


### PR DESCRIPTION
## Summary

Adds a new SQL fixture for `CREATE FOREIGN TABLE` that tests a combination not covered by existing fixtures:
- Schema-qualified column type with typmod (`pg_catalog.varchar(50)`)
- Common FDW option keys (`schema_name`, `table_name`)

The existing `upstream/foreign_data.sql` has extensive foreign table coverage but uses unqualified types like `integer`, `text`, `date`. This fixture adds coverage for qualified type names with type modifiers in foreign table column definitions.

## Review & Testing Checklist for Human

- [ ] Verify the SQL syntax is valid and the fixture parses correctly (run `pnpm test` in packages/deparser)
- [ ] Confirm this pattern (`pg_catalog.varchar(50)` in a foreign table) isn't already covered elsewhere in the fixtures

### Notes

- Link to Devin run: https://app.devin.ai/sessions/b20811a2d96c44a4a75fdf742aaa7978
- Requested by: Dan Lynch (@pyramation)