### PR TITLE
fix: remove pg_catalog prefix for unknown types in deparser

### DIFF
--- a/packages/deparser/src/deparser.ts
+++ b/packages/deparser/src/deparser.ts
@@ -2199,7 +2199,7 @@ export class Deparser implements DeparserVisitor {
         if (size != null) {
           return 'char';
         }
-        return 'pg_catalog.bpchar';
+        return 'bpchar';
       case 'varchar':
         return 'varchar';
       case 'numeric':
@@ -2213,7 +2213,7 @@ export class Deparser implements DeparserVisitor {
       case 'int8':
         return 'bigint';
       case 'real':
-        return 'pg_catalog.float4';
+        return 'float4';
       case 'time':
         return 'time';
       case 'timestamp':
@@ -2223,7 +2223,7 @@ export class Deparser implements DeparserVisitor {
       case 'bit':
         return 'bit';
       default:
-        return `pg_catalog.${typeName}`;
+        return typeName;
     }
   }
 


### PR DESCRIPTION
## Summary

Removes hardcoded `pg_catalog.` prefix from the `getPgCatalogTypeName` function in the TypeScript deparser. This fixes issues with extension types (citext, hstore, ltree, etc.) that don't live in `pg_catalog` but in the schema where the extension is installed (typically `public`).

PostgreSQL automatically searches `pg_catalog` first via the implicit search_path, so explicit qualification is unnecessary for built-in types and incorrect for extension types.

Changes:
- `bpchar` without size modifier: `pg_catalog.bpchar` → `bpchar`
- `real` type: `pg_catalog.float4` → `float4`
- Default/unknown types: `pg_catalog.${typeName}` → `typeName`

Related issue: constructive-io/constructive-planning#477

## Review & Testing Checklist for Human

- [ ] Verify that downstream consumers of pgsql-deparser don't rely on the `pg_catalog.` prefix being present in deparsed output
- [ ] Test deparsing a column with an extension type (e.g., `citext`) to confirm it no longer produces `pg_catalog.citext`
- [ ] Run the full test suite to ensure no regressions in type name handling

### Notes

This is a companion fix to constructive-db PR #179 which applies the same fix to the SQL deparser.

Link to Devin run: https://app.devin.ai/sessions/45dd8cf3c5c4475f974e0ba445857a70
Requested by: Dan Lynch (@pyramation)