### PR TITLE
fix(deparser): quote schema name in CreateSchemaStmt

### DIFF
--- a/packages/deparser/src/deparser.ts
+++ b/packages/deparser/src/deparser.ts
@@ -4273,7 +4273,7 @@ export class Deparser implements DeparserVisitor {
     }
 
     if (node.schemaname) {
-      output.push(node.schemaname);
+      output.push(QuoteUtils.quoteIdentifier(node.schemaname));
     }
 
     if (node.authrole) {


### PR DESCRIPTION
## Summary

The `CreateSchemaStmt` handler was not quoting the schema name, which caused parse errors when the schema name contained special characters like hyphens.

**Before:** `CREATE SCHEMA constructive-public;` (invalid SQL - hyphen interpreted as minus operator)
**After:** `CREATE SCHEMA "constructive-public";` (valid SQL)

This fix uses `QuoteUtils.quoteIdentifier()` to properly quote schema names that require quoting, consistent with how other identifiers are handled elsewhere in the deparser (e.g., in sequence statements at lines 9346 and 9387).

## Review & Testing Checklist for Human

- [ ] Verify the fix doesn't break any existing functionality by running `pnpm test` in `packages/deparser` (note: there are 12 pre-existing test failures unrelated to this change)
- [ ] Consider adding a dedicated test case for `CreateSchemaStmt` with special characters in schema names
- [ ] Verify that normal schema names (e.g., `public`) are NOT unnecessarily quoted after this change

**Test plan:**
```javascript
const { Deparser } = require('./packages/deparser/dist');

// Should output: CREATE SCHEMA "constructive-public";
Deparser.deparse({ stmts: [{ stmt: { CreateSchemaStmt: { schemaname: 'constructive-public' } }, stmt_len: 1 }] });

// Should output: CREATE SCHEMA public; (no quotes)
Deparser.deparse({ stmts: [{ stmt: { CreateSchemaStmt: { schemaname: 'public' } }, stmt_len: 1 }] });
```

### Notes

- Link to Devin run: https://app.devin.ai/sessions/f8178d7485484832b5507d277bbf2919
- Requested by: Dan Lynch (@pyramation)
- This bug was discovered while working on constructive-db where the pgpm packaging pipeline was failing due to invalid SQL being generated during the parse → deparse → re-parse round-trip.