### PR TITLE
fix(plpgsql-deparser): handle already hydrated expressions in hydrateExpression

### DIFF
--- a/packages/plpgsql-deparser/src/hydrate.ts
+++ b/packages/plpgsql-deparser/src/hydrate.ts
@@ -115,13 +115,18 @@ function hydrateNode(
 }
 
 function hydrateExpression(
-  query: string,
+  query: string | HydratedExprQuery,
   parseMode: number,
   path: string,
   options: HydrationOptions,
   errors: HydrationError[],
   stats: HydrationStats
 ): HydratedExprQuery {
+  // If query is already hydrated (from a previous hydration call), return it unchanged
+  if (isHydratedExpr(query)) {
+    return query;
+  }
+  
   if (parseMode === ParseMode.RAW_PARSE_PLPGSQL_ASSIGN1 ||
       parseMode === ParseMode.RAW_PARSE_PLPGSQL_ASSIGN2 ||
       parseMode === ParseMode.RAW_PARSE_PLPGSQL_ASSIGN3 ||


### PR DESCRIPTION
## Summary

Fixes a bug where `hydratePlpgsqlAst` would crash with `TypeError: query.indexOf is not a function` when called on an already-hydrated AST. This occurred because `hydrateExpression` expected `query` to always be a string, but when processing an already-hydrated AST, the `query` property is a `HydratedExprQuery` object.

The fix adds a check at the beginning of `hydrateExpression` to detect if the query is already hydrated (using the existing `isHydratedExpr` function) and return it unchanged.

**Use case:** This is needed for schema transformation pipelines where the same AST might be processed multiple times, such as in constructive-db's schema name transformer.

## Review & Testing Checklist for Human

- [ ] Verify the `isHydratedExpr` function correctly identifies all hydrated expression kinds (`raw`, `sql-stmt`, `sql-expr`, `assign`)
- [ ] Confirm the type signature change from `query: string` to `query: string | HydratedExprQuery` doesn't cause TypeScript issues downstream
- [ ] Run full test suite: `pnpm test` in `packages/plpgsql-deparser`

**Test plan:** After merging and publishing, update constructive-db to use the new version and verify the schema transformation pipeline works without the `query.indexOf` error.

### Notes

- Link to Devin run: https://app.devin.ai/sessions/f8178d7485484832b5507d277bbf2919
- Requested by: Dan Lynch (@pyramation)