### PR TITLE
fix(plpgsql-deparser): expand PLpgSQL_row fields when refname is '(unnamed row)'

### DIFF
--- a/packages/plpgsql-deparser/__tests__/__snapshots__/hydrate-demo.test.ts.snap
+++ b/packages/plpgsql-deparser/__tests__/__snapshots__/hydrate-demo.test.ts.snap
@@ -172,7 +172,7 @@ BEGIN
       GET DIAGNOSTICS v_rowcount = ;
       v_orders_upserted := v_rowcount;
       v_sql := format('SELECT count(*)::int FROM %I.%I WHERE org_id = $1 AND created_at >= $2 AND created_at < $3', 'app_public', 'app_order');
-      EXECUTE v_sql INTO (unnamed row) USING p_org_id, p_from_ts, p_to_ts;
+      EXECUTE v_sql INTO v_rowcount USING p_org_id, p_from_ts, p_to_ts;
       IF p_debug THEN
             RAISE NOTICE 'dynamic count(app_order)=%', v_rowcount;
       END IF;

--- a/packages/plpgsql-deparser/__tests__/pretty/__snapshots__/plpgsql-pretty.test.ts.snap
+++ b/packages/plpgsql-deparser/__tests__/pretty/__snapshots__/plpgsql-pretty.test.ts.snap
@@ -142,7 +142,7 @@ begin
           'app_public',
           'app_order'
         );
-      execute v_sql into (unnamed row) using p_org_id, p_from_ts, p_to_ts;
+      execute v_sql into v_rowcount using p_org_id, p_from_ts, p_to_ts;
       if p_debug then
             raise notice 'dynamic count(app_order)=%', v_rowcount;
       end if;
@@ -343,7 +343,7 @@ BEGIN
           'app_public',
           'app_order'
         );
-      EXECUTE v_sql INTO (unnamed row) USING p_org_id, p_from_ts, p_to_ts;
+      EXECUTE v_sql INTO v_rowcount USING p_org_id, p_from_ts, p_to_ts;
       IF p_debug THEN
             RAISE NOTICE 'dynamic count(app_order)=%', v_rowcount;
       END IF;


### PR DESCRIPTION
# fix(plpgsql-deparser): expand PLpgSQL_row fields when refname is '(unnamed row)'

## Summary

Fixes a bug where `SELECT INTO` and `EXECUTE ... INTO` statements targeting variables would output `INTO (unnamed row)` instead of the actual variable names like `INTO v_rowcount`.

When PostgreSQL parses a `SELECT INTO` statement, it creates a `PLpgSQL_row` datum with `refname` set to `"(unnamed row)"`. The actual variable names are stored in the `fields` array with `varno` references that point to the real variables in the `datums` array.

This fix modifies `deparseDatumName()` to:
1. Accept an optional `context` parameter to access the datums array
2. Check if `PLpgSQL_row.refname` is `"(unnamed row)"`
3. If so, expand the fields array by resolving varno references to get actual variable names
4. Return the comma-separated list of variable names

All callers of `deparseDatumName()` have been updated to pass the context parameter.

## Review & Testing Checklist for Human

- [ ] **Verify all callers updated**: Confirm that all 9 call sites of `deparseDatumName()` now pass the `context` parameter (lines 772, 813, 844, 1060, 1088, 1110, 1227, 1307, 1331)
- [ ] **Check recursive call safety**: The recursive call at line 1331 intentionally omits context to prevent infinite loops - verify this doesn't cause issues with nested row structures
- [ ] **Test with constructive-db**: After publishing, regenerate the constructive module and verify the `app_limits_inc` function no longer has `INTO (unnamed row)` syntax errors

### Test Plan
1. Merge and publish new plpgsql-deparser version
2. Update constructive-db to use new version
3. Run `pnpm run generate:metaschema-rls` to regenerate the constructive module
4. Verify generated functions in `application/constructive/deploy/schemas/constructive_limits_private/procedures/` have correct `INTO` clauses
5. Run `pnpm test -- rls.modular.test.ts` to verify RLS tests pass

### Notes
- This fix is blocking PR #229 in constructive-db which consolidates the constructive output with AST-based schema transformation
- Session: https://app.devin.ai/sessions/f8178d7485484832b5507d277bbf2919
- Requested by: Dan Lynch (@pyramation)