### PR TITLE
fix(plpgsql-deparser): fix PERFORM, INTO, and recfield bugs

### DIFF
--- a/packages/plpgsql-deparser/__tests__/__snapshots__/deparser-fixes.test.ts.snap
+++ b/packages/plpgsql-deparser/__tests__/__snapshots__/deparser-fixes.test.ts.snap
@@ -1,0 +1,157 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should handle INTO STRICT 1`] = `
+"DECLARE
+  v_id integer;
+BEGIN
+  SELECT id INTO STRICT v_id                  FROM users WHERE email = 'test@example.com';
+  RETURN v_id;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should handle INTO with CTE 1`] = `
+"DECLARE
+  v_total integer;
+BEGIN
+  WITH totals AS (
+          SELECT sum(amount) as total FROM orders
+      )
+      SELECT total INTO v_total              FROM totals;
+  RETURN v_total;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should handle INTO with UNION 1`] = `
+"DECLARE
+  v_count integer;
+BEGIN
+  SELECT count(*) INTO v_count              FROM (
+          SELECT id FROM users
+          UNION ALL
+          SELECT id FROM admins
+      ) combined;
+  RETURN v_count;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should handle INTO with dollar-quoted strings 1`] = `
+"DECLARE
+  v_result text;
+BEGIN
+  SELECT $tag$some FROM text$tag$ INTO v_result               FROM dual;
+  RETURN v_result;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should handle INTO with quoted identifiers 1`] = `
+"DECLARE
+  v_name text;
+BEGIN
+  SELECT "user-name" INTO v_name             FROM "my-schema"."user-table" WHERE id = 1;
+  RETURN v_name;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should insert INTO at correct position for simple SELECT 1`] = `
+"DECLARE
+  v_count integer;
+BEGIN
+  SELECT count(*) INTO v_count              FROM users;
+  RETURN v_count;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should not insert INTO inside subqueries 1`] = `
+"DECLARE
+  v_result integer;
+BEGIN
+  SELECT (SELECT max(id) FROM orders) INTO v_result               FROM users WHERE id = 1;
+  RETURN v_result;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes PERFORM SELECT fix should handle PERFORM with complex expressions 1`] = `
+"BEGIN
+  PERFORM set_config('search_path', 'public', true);
+  PERFORM nextval('my_sequence');
+  RETURN;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes PERFORM SELECT fix should handle PERFORM with subquery 1`] = `
+"BEGIN
+  PERFORM 1 FROM users WHERE id = 1;
+  RETURN;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes PERFORM SELECT fix should strip SELECT keyword from PERFORM statements 1`] = `
+"BEGIN
+  PERFORM pg_sleep(1);
+  RETURN;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes Record field qualification (recfield) should handle OLD and NEW record references 1`] = `
+"BEGIN
+  IF OLD.status <> NEW.status THEN
+      INSERT INTO audit_log (old_status, new_status) VALUES (OLD.status, NEW.status);
+  END IF;
+  RETURN NEW;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes Record field qualification (recfield) should handle SELECT INTO with record fields 1`] = `
+"BEGIN
+  SELECT is_active INTO new.is_active                    FROM users WHERE id = NEW.user_id;
+  RETURN NEW;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes Record field qualification (recfield) should handle custom record types 1`] = `
+"DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN SELECT id, name FROM users LOOP
+      RAISE NOTICE 'User: % - %', r.id, r.name;
+  END LOOP;
+  RETURN;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes Record field qualification (recfield) should handle record field assignment 1`] = `
+"BEGIN
+  NEW.created_at := COALESCE(NEW.created_at, now());
+  NEW.updated_at := now();
+  NEW.version := COALESCE(OLD.version, 0) + 1;
+  RETURN NEW;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes Record field qualification (recfield) should qualify record fields with parent record name in triggers 1`] = `
+"BEGIN
+  IF NEW.is_active THEN
+      NEW.updated_at := now();
+  END IF;
+  RETURN NEW;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes combined scenarios should handle PERFORM with record fields 1`] = `
+"BEGIN
+  PERFORM notify_change(NEW.id, NEW.status);
+  RETURN NEW;
+END"
+`;
+
+exports[`plpgsql-deparser bug fixes combined scenarios should handle SELECT INTO with subquery and record fields 1`] = `
+"DECLARE
+  v_count integer;
+BEGIN
+  SELECT count(*) INTO v_count              FROM orders WHERE user_id = NEW.user_id;
+  IF v_count > 100 THEN
+      NEW.is_premium := true;
+  END IF;
+  RETURN NEW;
+END"
+`;

--- a/packages/plpgsql-deparser/__tests__/__snapshots__/deparser-fixes.test.ts.snap
+++ b/packages/plpgsql-deparser/__tests__/__snapshots__/deparser-fixes.test.ts.snap
@@ -4,7 +4,7 @@ exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should handl
 "DECLARE
   v_id integer;
 BEGIN
-  SELECT id INTO STRICT v_id                  FROM users WHERE email = 'test@example.com';
+  SELECT id INTO STRICT v_id FROM users WHERE email = 'test@example.com';
   RETURN v_id;
 END"
 `;
@@ -16,7 +16,7 @@ BEGIN
   WITH totals AS (
           SELECT sum(amount) as total FROM orders
       )
-      SELECT total INTO v_total              FROM totals;
+      SELECT total INTO v_total FROM totals;
   RETURN v_total;
 END"
 `;
@@ -25,7 +25,7 @@ exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should handl
 "DECLARE
   v_count integer;
 BEGIN
-  SELECT count(*) INTO v_count              FROM (
+  SELECT count(*) INTO v_count FROM (
           SELECT id FROM users
           UNION ALL
           SELECT id FROM admins
@@ -38,7 +38,7 @@ exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should handl
 "DECLARE
   v_result text;
 BEGIN
-  SELECT $tag$some FROM text$tag$ INTO v_result               FROM dual;
+  SELECT $tag$some FROM text$tag$ INTO v_result FROM dual;
   RETURN v_result;
 END"
 `;
@@ -47,7 +47,7 @@ exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should handl
 "DECLARE
   v_name text;
 BEGIN
-  SELECT "user-name" INTO v_name             FROM "my-schema"."user-table" WHERE id = 1;
+  SELECT "user-name" INTO v_name FROM "my-schema"."user-table" WHERE id = 1;
   RETURN v_name;
 END"
 `;
@@ -56,7 +56,7 @@ exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should inser
 "DECLARE
   v_count integer;
 BEGIN
-  SELECT count(*) INTO v_count              FROM users;
+  SELECT count(*) INTO v_count FROM users;
   RETURN v_count;
 END"
 `;
@@ -65,7 +65,7 @@ exports[`plpgsql-deparser bug fixes INTO clause depth-aware scanner should not i
 "DECLARE
   v_result integer;
 BEGIN
-  SELECT (SELECT max(id) FROM orders) INTO v_result               FROM users WHERE id = 1;
+  SELECT (SELECT max(id) FROM orders) INTO v_result FROM users WHERE id = 1;
   RETURN v_result;
 END"
 `;
@@ -103,7 +103,7 @@ END"
 
 exports[`plpgsql-deparser bug fixes Record field qualification (recfield) should handle SELECT INTO with record fields 1`] = `
 "BEGIN
-  SELECT is_active INTO new.is_active                    FROM users WHERE id = NEW.user_id;
+  SELECT is_active INTO new.is_active FROM users WHERE id = NEW.user_id;
   RETURN NEW;
 END"
 `;
@@ -148,7 +148,7 @@ exports[`plpgsql-deparser bug fixes combined scenarios should handle SELECT INTO
 "DECLARE
   v_count integer;
 BEGIN
-  SELECT count(*) INTO v_count              FROM orders WHERE user_id = NEW.user_id;
+  SELECT count(*) INTO v_count FROM orders WHERE user_id = NEW.user_id;
   IF v_count > 100 THEN
       NEW.is_premium := true;
   END IF;

--- a/packages/plpgsql-deparser/__tests__/deparser-fixes.test.ts
+++ b/packages/plpgsql-deparser/__tests__/deparser-fixes.test.ts
@@ -1,0 +1,328 @@
+import { loadModule, parsePlPgSQLSync } from '@libpg-query/parser';
+import { deparseSync, PLpgSQLParseResult } from '../src';
+
+describe('plpgsql-deparser bug fixes', () => {
+  beforeAll(async () => {
+    await loadModule();
+  });
+
+  describe('PERFORM SELECT fix', () => {
+    it('should strip SELECT keyword from PERFORM statements', () => {
+      const sql = `CREATE FUNCTION test_perform() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM pg_sleep(1);
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+      expect(deparsed).toContain('PERFORM pg_sleep');
+      expect(deparsed).not.toMatch(/PERFORM\s+SELECT/i);
+    });
+
+    it('should handle PERFORM with complex expressions', () => {
+      const sql = `CREATE FUNCTION test_perform_complex() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM set_config('search_path', 'public', true);
+    PERFORM nextval('my_sequence');
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+      expect(deparsed).not.toMatch(/PERFORM\s+SELECT/i);
+    });
+
+    it('should handle PERFORM with subquery', () => {
+      const sql = `CREATE FUNCTION test_perform_subquery() RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM 1 FROM users WHERE id = 1;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+      expect(deparsed).not.toMatch(/PERFORM\s+SELECT/i);
+    });
+  });
+
+  describe('INTO clause depth-aware scanner', () => {
+    it('should insert INTO at correct position for simple SELECT', () => {
+      const sql = `CREATE FUNCTION test_into_simple() RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_count integer;
+BEGIN
+    SELECT count(*) INTO v_count FROM users;
+    RETURN v_count;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+      expect(deparsed).toContain('INTO');
+    });
+
+    it('should not insert INTO inside subqueries', () => {
+      const sql = `CREATE FUNCTION test_into_subquery() RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_result integer;
+BEGIN
+    SELECT (SELECT max(id) FROM orders) INTO v_result FROM users WHERE id = 1;
+    RETURN v_result;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+    });
+
+    it('should handle INTO with CTE', () => {
+      const sql = `CREATE FUNCTION test_into_cte() RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_total integer;
+BEGIN
+    WITH totals AS (
+        SELECT sum(amount) as total FROM orders
+    )
+    SELECT total INTO v_total FROM totals;
+    RETURN v_total;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+    });
+
+    it('should handle INTO with UNION', () => {
+      const sql = `CREATE FUNCTION test_into_union() RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_count integer;
+BEGIN
+    SELECT count(*) INTO v_count FROM (
+        SELECT id FROM users
+        UNION ALL
+        SELECT id FROM admins
+    ) combined;
+    RETURN v_count;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+    });
+
+    it('should handle INTO with quoted identifiers', () => {
+      const sql = `CREATE FUNCTION test_into_quoted() RETURNS text
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_name text;
+BEGIN
+    SELECT "user-name" INTO v_name FROM "my-schema"."user-table" WHERE id = 1;
+    RETURN v_name;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+    });
+
+    it('should handle INTO with dollar-quoted strings', () => {
+      const sql = `CREATE FUNCTION test_into_dollar_quote() RETURNS text
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_result text;
+BEGIN
+    SELECT $tag$some FROM text$tag$ INTO v_result FROM dual;
+    RETURN v_result;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+    });
+
+    it('should handle INTO STRICT', () => {
+      const sql = `CREATE FUNCTION test_into_strict() RETURNS integer
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_id integer;
+BEGIN
+    SELECT id INTO STRICT v_id FROM users WHERE email = 'test@example.com';
+    RETURN v_id;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+      expect(deparsed).toContain('STRICT');
+    });
+  });
+
+  describe('Record field qualification (recfield)', () => {
+    it('should qualify record fields with parent record name in triggers', () => {
+      const sql = `CREATE FUNCTION test_trigger() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.is_active THEN
+        NEW.updated_at := now();
+    END IF;
+    RETURN NEW;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+    });
+
+    it('should handle OLD and NEW record references', () => {
+      const sql = `CREATE FUNCTION test_trigger_old_new() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.status <> NEW.status THEN
+        INSERT INTO audit_log (old_status, new_status) VALUES (OLD.status, NEW.status);
+    END IF;
+    RETURN NEW;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+    });
+
+    it('should handle record field assignment', () => {
+      const sql = `CREATE FUNCTION test_record_assign() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.created_at := COALESCE(NEW.created_at, now());
+    NEW.updated_at := now();
+    NEW.version := COALESCE(OLD.version, 0) + 1;
+    RETURN NEW;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+    });
+
+    it('should handle SELECT INTO with record fields', () => {
+      const sql = `CREATE FUNCTION test_select_into_record() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    SELECT is_active INTO NEW.is_active FROM users WHERE id = NEW.user_id;
+    RETURN NEW;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+    });
+
+    it('should handle custom record types', () => {
+      const sql = `CREATE FUNCTION test_custom_record() RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN SELECT id, name FROM users LOOP
+        RAISE NOTICE 'User: % - %', r.id, r.name;
+    END LOOP;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+    });
+  });
+
+  describe('combined scenarios', () => {
+    it('should handle PERFORM with record fields', () => {
+      const sql = `CREATE FUNCTION test_perform_record() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM notify_change(NEW.id, NEW.status);
+    RETURN NEW;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+      expect(deparsed).not.toMatch(/PERFORM\s+SELECT/i);
+    });
+
+    it('should handle SELECT INTO with subquery and record fields', () => {
+      const sql = `CREATE FUNCTION test_complex_trigger() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_count integer;
+BEGIN
+    SELECT count(*) INTO v_count FROM orders WHERE user_id = NEW.user_id;
+    IF v_count > 100 THEN
+        NEW.is_premium := true;
+    END IF;
+    RETURN NEW;
+END;
+$$`;
+
+      const parsed = parsePlPgSQLSync(sql) as unknown as PLpgSQLParseResult;
+      const deparsed = deparseSync(parsed);
+
+      expect(deparsed).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes three bugs in the plpgsql-deparser that were causing invalid SQL output:

1. **PERFORM SELECT fix**: The PL/pgSQL parser stores PERFORM statements internally as "SELECT ...", so the deparser was outputting invalid `PERFORM SELECT ...` syntax. Now strips the leading SELECT keyword.

2. **INTO clause depth-aware scanner**: The old regex-based approach for inserting INTO clauses would incorrectly insert INTO inside subqueries. Replaced with a depth-aware scanner (~150 lines) that tracks parentheses, quotes, comments, and dollar quotes to find the correct insertion point only at depth 0.

3. **Record field qualification**: The deparser was returning just `fieldname` instead of the full qualified reference like `new.is_active`. Now uses `recparentno` to look up the parent record and construct the full reference.

## Updates since last revision

- **Whitespace normalization fix**: The parser strips `INTO <target>` from the stored query but leaves the original whitespace behind. This was causing large gaps in output like `SELECT x INTO y                    FROM z`. Now normalizes leading whitespace after INTO insertion to a single space.

- **Round-trip AST testing**: Upgraded all 17 test cases to use round-trip testing (parse → deparse → reparse → compare cleaned ASTs). Added `normalizeQueryWhitespace` to `cleanPlpgsqlTree` to handle indentation differences in embedded SQL queries while preserving content inside string literals and dollar-quoted strings.

## Review & Testing Checklist for Human

- [ ] **Verify depth-aware scanner edge cases**: The `findIntoInsertionPoint` function (lines 1090-1243) is complex state machine logic. Test with: nested subqueries, CTEs, UNION, dollar-quoted strings containing "FROM", comments containing keywords, escaped quotes
- [ ] **Test generated SQL against PostgreSQL**: Round-trip tests verify AST equality but don't validate the SQL is actually executable. Run a few test cases against a real PostgreSQL instance
- [ ] **Review `normalizeQueryWhitespace` function**: This function (~100 lines in test-utils/index.ts) normalizes whitespace for AST comparison. Verify it doesn't mask real semantic differences by being too aggressive
- [ ] **Verify record field qualification in triggers**: Test with OLD/NEW references in various trigger scenarios

**Recommended test plan**: 
1. Run the new snapshot tests locally
2. Take a few of the snapshot outputs and execute them as PL/pgSQL function bodies in a real PostgreSQL database to verify syntax validity
3. Create a trigger function using OLD.field and NEW.field references and verify it parses/deparses correctly

### Notes

This PR upstreams patches 1-3 from [constructive-db PR #229](https://github.com/constructive-io/constructive-db/pull/229). Patch 4 (RETURN statement handling) is being handled separately as it requires design discussion about passing return-type context.

Link to Devin run: https://app.devin.ai/sessions/8e1c971e9b194cd9a7dda034c89bd74b
Requested by: Dan Lynch (@pyramation)