### PR TITLE
fix(plpgsql-deparser): fix 2 more failing fixtures (189/190 now pass)

### DIFF
--- a/packages/plpgsql-deparser/__tests__/plpgsql-deparser.test.ts
+++ b/packages/plpgsql-deparser/__tests__/plpgsql-deparser.test.ts
@@ -33,18 +33,13 @@ describe('PLpgSQLDeparser', () => {
 
   describe('round-trip tests using generated.json', () => {
     // Known failing fixtures due to pre-existing deparser issues:
-    // - Schema qualification loss (pg_catalog.pg_class%rowtype[] -> pg_class%rowtype[])
-    // - Tagged dollar quote reconstruction ($tag$...$tag$ not supported)
-    // - Exception block handling issues
     // TODO: Fix these underlying issues and remove from allowlist
     // Remaining known failing fixtures:
-    // - plpgsql_varprops-13.sql: nested DECLARE inside FOR loop (loop variable scope issue)
-    // - plpgsql_transaction-17.sql: CURSOR FOR loop with EXCEPTION block
-    // - plpgsql_control-15.sql: labeled block with EXIT statement
+    // - plpgsql_varprops-13.sql: nested DECLARE inside FOR loop - variables declared inside
+    //   the loop body are hoisted to the top-level DECLARE section, changing semantics
+    //   (variables should be reinitialized on each loop iteration)
     const KNOWN_FAILING_FIXTURES = new Set([
       'plpgsql_varprops-13.sql',
-      'plpgsql_transaction-17.sql',
-      'plpgsql_control-15.sql',
     ]);
 
     it('should round-trip ALL generated fixtures (excluding known failures)', async () => {


### PR DESCRIPTION
# fix(plpgsql-deparser): fix 2 more failing fixtures (189/190 now pass)

## Summary

This PR fixes 2 of the 3 remaining failing round-trip test fixtures, bringing the pass rate from 187/190 to 189/190.

**Fixes:**
1. **Cursor declaration syntax** - Output `cursor_name CURSOR FOR query` instead of `cursor_name refcursor CURSOR FOR query` (fixes `plpgsql_transaction-17.sql`)
2. **Label placement** - Output block labels before DECLARE section instead of between DECLARE and BEGIN (fixes `plpgsql_control-15.sql`)
3. **Tagged dollar quote handling** - Test utils now properly handle `$tag$` delimiters, not just `$$`
4. **Qualified variable names** - Preserve block-qualified references like `lbl.a` in FOR loops

**Remaining failure:** `plpgsql_varprops-13.sql` - nested DECLARE inside FOR loop (variables are hoisted to top-level DECLARE, changing semantics)

## Review & Testing Checklist for Human

- [ ] Verify cursor declaration syntax is correct for various cursor types (explicit cursors, bound cursors, etc.)
- [ ] Test labeled blocks with DECLARE sections to ensure labels appear in correct position
- [ ] Check that the `skipLabel` parameter doesn't affect nested blocks that should still have their own labels

### Test Plan
```bash
cd packages/plpgsql-deparser
npm test
```
Verify output shows "Round-trip tested 189 of 190 fixtures (1 known failures skipped)"

### Notes
- The `escapedTag` variable in `extractBodyFromSql` is computed but not used - this is harmless dead code
- Link to Devin run: https://app.devin.ai/sessions/8e1c971e9b194cd9a7dda034c89bd74b
- Requested by: @pyramation