### PR TITLE
fix(plpgsql-deparser): support nested DECLARE blocks inside FOR loops

### DIFF
--- a/packages/plpgsql-deparser/__tests__/plpgsql-deparser.test.ts
+++ b/packages/plpgsql-deparser/__tests__/plpgsql-deparser.test.ts
@@ -32,14 +32,15 @@ describe('PLpgSQLDeparser', () => {
   });
 
   describe('round-trip tests using generated.json', () => {
-    // Known failing fixtures due to pre-existing deparser issues:
-    // TODO: Fix these underlying issues and remove from allowlist
-    // Remaining known failing fixtures:
-    // - plpgsql_varprops-13.sql: nested DECLARE inside FOR loop - variables declared inside
-    //   the loop body are hoisted to the top-level DECLARE section, changing semantics
-    //   (variables should be reinitialized on each loop iteration)
-    const KNOWN_FAILING_FIXTURES = new Set([
-      'plpgsql_varprops-13.sql',
+    // All 190 fixtures now pass round-trip testing!
+    // Previously failing fixtures that have been fixed:
+    // - Schema qualification (pg_catalog prefix preserved)
+    // - Exception block handling
+    // - Cursor FOR loops
+    // - Labeled blocks with EXIT statements
+    // - Nested DECLARE inside FOR loops (lineno-based scope tracking)
+    const KNOWN_FAILING_FIXTURES = new Set<string>([
+      // No known failures - all fixtures pass!
     ]);
 
     it('should round-trip ALL generated fixtures (excluding known failures)', async () => {


### PR DESCRIPTION
# fix(plpgsql-deparser): support nested DECLARE blocks inside FOR loops

## Summary
Implements lineno-based scope tracking to correctly assign variables to their enclosing blocks. Previously, variables declared inside a FOR loop body were hoisted to the top-level DECLARE section, which changed semantics (variables should be reinitialized on each loop iteration).

The fix uses line numbers from the AST to determine which variables belong to which blocks:
- Variables with `lineno <= topLevelBlockLineno` stay in the top-level DECLARE
- Variables with `lineno > topLevelBlockLineno` are assigned to the nearest nested block whose `lineno` is greater than the variable's `lineno`

This fixes the last remaining failing fixture (`plpgsql_varprops-13.sql`). All 190 fixtures now pass round-trip testing.

## Review & Testing Checklist for Human
- [ ] Verify the lineno-based algorithm handles edge cases correctly (e.g., multiple nested blocks at same nesting level, deeply nested blocks)
- [ ] Test with a real PL/pgSQL function that has nested DECLARE inside a FOR loop to confirm the output is valid syntax
- [ ] Check that functions WITHOUT nested DECLARE blocks still work correctly (regression test)

**Recommended test plan:** Run the round-trip tests locally (`npm test` in `packages/plpgsql-deparser`) and manually inspect the output for `plpgsql_varprops-13.sql` to verify the nested DECLARE appears in the correct position.

### Notes
- The algorithm falls back to keeping all variables at top-level when `topLevelBlockLineno` is undefined (discovered during debugging with `big-function.sql`)
- Link to Devin run: https://app.devin.ai/sessions/8e1c971e9b194cd9a7dda034c89bd74b
- Requested by: @pyramation