### PR TITLE
refactor: rename renameMap to schemaRenameMap for clarity

### DIFF
--- a/packages/plpgsql-deparser/__tests__/__snapshots__/schema-rename-mapped.test.ts.snap
+++ b/packages/plpgsql-deparser/__tests__/__snapshots__/schema-rename-mapped.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`schema rename mapped should transform schema names and snapshot rename map and output: rename-map 1`] = `
+exports[`schema rename mapped should transform schema names and snapshot schema rename map and output: schema-rename-map 1`] = `
 {
   "app_internal": {
     "newSchema": "myapp_internal_v2",
@@ -187,7 +187,7 @@ exports[`schema rename mapped should transform schema names and snapshot rename 
 }
 `;
 
-exports[`schema rename mapped should transform schema names and snapshot rename map and output: transformed-sql 1`] = `
+exports[`schema rename mapped should transform schema names and snapshot schema rename map and output: transformed-sql 1`] = `
 "CREATE FUNCTION myapp_v2.get_user_stats(
   p_user_id int
 ) RETURNS int LANGUAGE plpgsql AS $$DECLARE


### PR DESCRIPTION
## Summary

Renames `renameMap` to `schemaRenameMap` throughout the schema rename test to make it explicit that this map is specifically for schema renaming. This prepares for future extensibility where other rename maps (for tables, functions, triggers, etc.) may be added.

Changes:
- `RenameMap` interface → `SchemaRenameMap`
- `renameMap` variable → `schemaRenameMap` in all function parameters and usages
- `renameMapSummary` → `schemaRenameMapSummary`
- Updated snapshot names from `rename-map` to `schema-rename-map`

## Review & Testing Checklist for Human

- [ ] Verify no `renameMap` references were missed (search for `renameMap` in the test file)
- [ ] Confirm snapshot file keys match the updated test description

**Test plan:** Run `pnpm test` in `packages/plpgsql-deparser` - all 58 tests and 28 snapshots should pass.

### Notes
- Link to Devin run: https://app.devin.ai/sessions/8e1c971e9b194cd9a7dda034c89bd74b
- Requested by: @pyramation