### PR TITLE
feat(plpgsql-deparser): add PLpgSQL_type hydration support

### DIFF
--- a/packages/plpgsql-deparser/src/hydrate-types.ts
+++ b/packages/plpgsql-deparser/src/hydrate-types.ts
@@ -47,6 +47,20 @@ export type HydratedExprQuery =
   | HydratedExprSqlExpr
   | HydratedExprAssign;
 
+/**
+ * Hydrated PLpgSQL_type typname field.
+ * The typname string (e.g., "schema.typename") is parsed into a TypeName AST node.
+ */
+export interface HydratedTypeName {
+  kind: 'type-name';
+  /** The original typname string */
+  original: string;
+  /** The parsed TypeName AST node (from parsing SELECT NULL::typename) */
+  typeNameNode: Node;
+  /** Optional suffix like %rowtype or %type that was stripped before parsing */
+  suffix?: string;
+}
+
 export interface HydratedPLpgSQL_expr {
   query: HydratedExprQuery;
 }
@@ -77,4 +91,6 @@ export interface HydrationStats {
   assignmentExpressions: number;
   sqlExpressions: number;
   rawExpressions: number;
+  /** Number of PLpgSQL_type nodes with hydrated typname */
+  typeNameExpressions: number;
 }

--- a/packages/plpgsql-deparser/src/index.ts
+++ b/packages/plpgsql-deparser/src/index.ts
@@ -21,4 +21,4 @@ export const deparseFunction = async (
 export { PLpgSQLDeparser, PLpgSQLDeparserOptions, ReturnInfo, ReturnInfoKind };
 export * from './types';
 export * from './hydrate-types';
-export { hydratePlpgsqlAst, dehydratePlpgsqlAst, isHydratedExpr, getOriginalQuery, DehydrationOptions } from './hydrate';
+export { hydratePlpgsqlAst, dehydratePlpgsqlAst, isHydratedExpr, isHydratedTypeName, getOriginalQuery, DehydrationOptions } from './hydrate';


### PR DESCRIPTION
## Summary

This PR adds AST-based hydration for `PLpgSQL_type` nodes (variable type declarations like `v_user schema.users`). Previously, type names in PL/pgSQL variable declarations were stored as plain strings, requiring string manipulation for schema transformations. Now, schema-qualified type names are parsed into `TypeName` AST nodes that can be transformed using the same SQL visitor pattern as other schema references.

Key changes:
- Added `HydratedTypeName` interface representing a hydrated type name with the original string, parsed TypeName AST node, and optional suffix (%rowtype/%type)
- Implemented `hydrateTypeName()` function that parses typname strings into TypeName AST nodes by wrapping them in a cast expression (`SELECT NULL::typename`)
- Added PLpgSQL_type handling in `hydrateNode()` to hydrate schema-qualified type declarations
- Implemented `dehydrateTypeName()` to convert hydrated TypeName AST back to strings
- Exported `isHydratedTypeName` helper function for type checking
- Updated schema transformation tests to use the hydrated AST instead of string manipulation

**Important**: This is a breaking change for code that assumes `PLpgSQL_type.typname` is always a string. After hydration, schema-qualified types will have a `HydratedTypeName` object instead.

## Review & Testing Checklist for Human

- [ ] **Verify schema qualification regex** (`/^[^"]*\.|"[^"]*"\./i`) handles edge cases with quoted identifiers correctly - this heuristic determines which types get hydrated
- [ ] **Test error handling behavior** - hydration throws on AST parsing failure (no fallback) per design requirement. Verify this is acceptable for all use cases
- [ ] **Check downstream consumers** - constructive-db and any other code using PLpgSQL_type nodes will need updates to handle `HydratedTypeName` objects
- [ ] **Test with real PL/pgSQL functions** that have schema-qualified type declarations, including edge cases like `%rowtype` suffixes and hyphenated schema names in quotes

### Test Plan
1. Run `pnpm test` in packages/plpgsql-deparser - all 58 tests should pass
2. Test schema transformation with a function containing `DECLARE v_user "my-schema".users;` to verify quoted identifiers work
3. Verify constructive-db's schema transformation still works after updating to use this upstream hydration

### Notes
- The `as any` type casts in `deparseTypeNameNode` work around TypeScript union type limitations - the code is correct but the types are imprecise
- Simple built-in types without schema qualification (e.g., `integer`, `text`) are intentionally NOT hydrated since they don't benefit from AST transformation

Link to Devin run: https://app.devin.ai/sessions/6e7a47775f6d4e4cbfdd8106400fe4ee
Requested by: Dan Lynch (@pyramation)