### PR TITLE
test(plpgsql-deparser): add trigger function fixture with FOUND/NEW/OLD/TG_OP examples

### DIFF
--- a/__fixtures__/plpgsql-pretty/trigger-function.sql
+++ b/__fixtures__/plpgsql-pretty/trigger-function.sql
@@ -1,0 +1,22 @@
+CREATE FUNCTION trigger_with_special_vars() RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        NEW.created_at := now();
+        RETURN NEW;
+    ELSIF TG_OP = 'UPDATE' THEN
+        IF OLD.id IS DISTINCT FROM NEW.id THEN
+            RAISE EXCEPTION 'IMMUTABLE_FIELD';
+        END IF;
+        NEW.updated_at := now();
+        RETURN NEW;
+    ELSIF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'NOT_FOUND';
+    END IF;
+    RETURN NEW;
+END;
+$$

--- a/packages/plpgsql-deparser/__tests__/pretty/__snapshots__/plpgsql-pretty.test.ts.snap
+++ b/packages/plpgsql-deparser/__tests__/pretty/__snapshots__/plpgsql-pretty.test.ts.snap
@@ -208,6 +208,27 @@ exports[`lowercase: simple-function.sql 1`] = `
 end"
 `;
 
+exports[`lowercase: trigger-function.sql 1`] = `
+"begin
+  if TG_OP = 'INSERT' then
+      NEW.created_at := now();
+      return NEW;
+  elsif TG_OP = 'UPDATE' then
+      if OLD.id IS DISTINCT FROM NEW.id then
+            raise exception 'IMMUTABLE_FIELD';
+      end if;
+      NEW.updated_at := now();
+      return NEW;
+  elsif TG_OP = 'DELETE' then
+      return OLD;
+  end if;
+  if NOT FOUND then
+      raise exception 'NOT_FOUND';
+  end if;
+  return NEW;
+end"
+`;
+
 exports[`uppercase: big-function.sql 1`] = `
 "DECLARE
   v_orders_scanned int := 0;
@@ -413,5 +434,26 @@ END"
 exports[`uppercase: simple-function.sql 1`] = `
 "BEGIN
   RETURN a + b;
+END"
+`;
+
+exports[`uppercase: trigger-function.sql 1`] = `
+"BEGIN
+  IF TG_OP = 'INSERT' THEN
+      NEW.created_at := now();
+      RETURN NEW;
+  ELSIF TG_OP = 'UPDATE' THEN
+      IF OLD.id IS DISTINCT FROM NEW.id THEN
+            RAISE EXCEPTION 'IMMUTABLE_FIELD';
+      END IF;
+      NEW.updated_at := now();
+      RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+      RETURN OLD;
+  END IF;
+  IF NOT FOUND THEN
+      RAISE EXCEPTION 'NOT_FOUND';
+  END IF;
+  RETURN NEW;
 END"
 `;

--- a/packages/plpgsql-deparser/__tests__/pretty/plpgsql-pretty.test.ts
+++ b/packages/plpgsql-deparser/__tests__/pretty/plpgsql-pretty.test.ts
@@ -5,6 +5,7 @@ const prettyTest = new PlpgsqlPrettyTest([
   'simple-function.sql',
   'if-else-function.sql',
   'loop-function.sql',
+  'trigger-function.sql',
 ]);
 
 prettyTest.generateTests();


### PR DESCRIPTION
## Summary

Adds a new test fixture for PL/pgSQL trigger functions that demonstrates the deparser's handling of special variables: `TG_OP`, `NEW`, `OLD`, and `FOUND`. These are PL/pgSQL reserved words that should be output in uppercase without quotes.

The fixture covers common trigger patterns:
- Checking `TG_OP` for INSERT/UPDATE/DELETE operations
- Accessing `NEW` and `OLD` record variables
- Using `FOUND` to check if a previous statement found rows

## Review & Testing Checklist for Human

- [ ] Verify the fixture SQL is valid PL/pgSQL syntax
- [ ] Confirm snapshots show uppercase `TG_OP`, `NEW`, `OLD`, `FOUND` without quotes (they do)

### Notes

This fixture was added as part of work on AST-based procedure generators in constructive-db (PR #319). The snapshots confirm that the pgsql-parser deparser already correctly handles these PL/pgSQL special variables.

**Requested by:** Dan Lynch (@pyramation)  
**Link to Devin run:** https://app.devin.ai/sessions/6c4e0d41e8d445cebebab85e29243ab2