### PR TITLE
feat(transform)!: drop transformVerifyCalls

### DIFF
--- a/packages/transform/__fixtures__/input/kitchen-sink.sql
+++ b/packages/transform/__fixtures__/input/kitchen-sink.sql
@@ -284,12 +284,12 @@ ANALYZE "other-schema".audit_log;
 -- =============================================================================
 -- 25. Verify function calls (string literal patterns)
 -- =============================================================================
-SELECT verify_schema('my-schema');
-SELECT verify_table('my-schema.users');
-SELECT verify_function('my-schema.get_user_by_id');
-SELECT verify_trigger('my-schema.trg_audit_insert');
-SELECT verify_type('my-schema.user_status_type');
-SELECT verify_domain('my-schema.positive_int');
+SELECT assert_schema('my-schema'::regnamespace);
+SELECT assert_table('my-schema.users'::regclass);
+SELECT assert_function('my-schema.get_user_by_id(uuid)'::regprocedure);
+SELECT assert_trigger('my-schema.users'::regclass, 'trg_audit_insert', 'my-schema.tg_audit'::regproc, 5);
+SELECT assert_type('my-schema.user_status_type'::regtype);
+SELECT assert_domain('my-schema.positive_int'::regtype, 'int4'::regtype);
 
 -- =============================================================================
 -- 26. JSON string values with schema names

--- a/packages/transform/__fixtures__/output/kitchen-sink.sql
+++ b/packages/transform/__fixtures__/output/kitchen-sink.sql
@@ -225,17 +225,17 @@ VACUUM my_schema.users;
 
 ANALYZE other_schema.audit_log;
 
-SELECT verify_schema('my_schema');
+SELECT assert_schema(CAST('my_schema' AS regnamespace));
 
-SELECT verify_table('my_schema.users');
+SELECT assert_table(CAST('my_schema.users' AS regclass));
 
-SELECT verify_function('my_schema.get_user_by_id');
+SELECT assert_function(CAST('my_schema.get_user_by_id(uuid)' AS regprocedure));
 
-SELECT verify_trigger('my_schema.trg_audit_insert');
+SELECT assert_trigger(CAST('my_schema.users' AS regclass), 'trg_audit_insert', CAST('my_schema.tg_audit' AS regproc), 5);
 
-SELECT verify_type('my_schema.user_status_type');
+SELECT assert_type(CAST('my_schema.user_status_type' AS regtype));
 
-SELECT verify_domain('my_schema.positive_int');
+SELECT assert_domain(CAST('my_schema.positive_int' AS regtype), CAST('int4' AS regtype));
 
 SELECT '{"schema":"my_schema"}'::jsonb;
 

--- a/packages/transform/__tests__/transform.test.ts
+++ b/packages/transform/__tests__/transform.test.ts
@@ -16,7 +16,6 @@ import {
   transformSql,
   TransformSqlOptions,
   transformSqlStatement,
-  transformVerifyCalls,
   validateNoUntransformedSchemas,
   validateRoundTrip,
 } from '../src';
@@ -136,29 +135,6 @@ describe('transform_comments', () => {
     const result = freshResult();
     const out = transformComments(content, DEFAULT_MAPPING, result);
     expect(out).toBe(content);
-  });
-});
-
-describe('transform_verify_calls', () => {
-  it('transforms schema names inside verify_function calls', () => {
-    const content = "SELECT verify_function('my-schema.do_something');";
-    const result = freshResult();
-    const out = transformVerifyCalls(content, DEFAULT_MAPPING, result);
-    expect(out).toContain("verify_function('my_schema.do_something')");
-  });
-
-  it('transforms verify_table, verify_trigger, etc.', () => {
-    const content = "SELECT verify_table('my-schema.users');";
-    const result = freshResult();
-    const out = transformVerifyCalls(content, DEFAULT_MAPPING, result);
-    expect(out).toContain("verify_table('my_schema.users')");
-  });
-
-  it('transforms verify_schema with just the schema name', () => {
-    const content = "SELECT verify_schema('my-schema');";
-    const result = freshResult();
-    const out = transformVerifyCalls(content, DEFAULT_MAPPING, result);
-    expect(out).toContain("verify_schema('my_schema')");
   });
 });
 
@@ -753,7 +729,6 @@ describe('transform_sql (full pipeline)', () => {
     ].join('\n');
 
     const opts: TransformSqlOptions = {
-      prePasses: [transformVerifyCalls],
     };
     const { content } = transformSql(input, DEFAULT_MAPPING, opts);
     expect(content).toContain("verify_table('my_schema.users')");
@@ -817,7 +792,7 @@ describe('transform_sql (full pipeline)', () => {
     ].join('\n');
 
     const opts: TransformSqlOptions = {
-      prePasses: [transformVerifyCalls, transformJsonStringValues],
+      prePasses: [transformJsonStringValues],
     };
     const { content } = transformSql(input, DEFAULT_MAPPING, opts);
     expect(content).toContain("verify_table('my_schema.config')");
@@ -883,7 +858,7 @@ const FIXTURE_FILES = fs
 
 describe.each(FIXTURE_FILES)('fixture: %s', (file) => {
   const FIXTURE_OPTS: TransformSqlOptions = {
-    prePasses: [transformVerifyCalls, transformJsonStringValues],
+    prePasses: [transformJsonStringValues],
   };
   const input = fs.readFileSync(path.join(FIXTURE_INPUT_DIR, file), 'utf8');
 
@@ -941,7 +916,7 @@ describe('kitchen-sink fixture', () => {
       'utf8'
     );
     const { result } = transformSql(input, DEFAULT_MAPPING, {
-      prePasses: [transformVerifyCalls, transformJsonStringValues],
+      prePasses: [transformJsonStringValues],
     });
     expect(result.schemasFound).toContain('my-schema');
     expect(result.schemasFound).toContain('other-schema');

--- a/packages/transform/package.json
+++ b/packages/transform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pgsql/transform",
-  "version": "18.16.0",
+  "version": "18.17.0",
   "author": "Constructive <developers@constructive.io>",
   "description": "AST-based SQL transformation, qualification, classification and closure analysis for PostgreSQL",
   "main": "index.js",

--- a/packages/transform/scripts/make-fixtures.ts
+++ b/packages/transform/scripts/make-fixtures.ts
@@ -19,7 +19,6 @@ import {
   transformJsonStringValues,
   transformSql,
   TransformSqlOptions,
-  transformVerifyCalls,
 } from '../src';
 
 const FIXTURES_DIR = path.resolve(__dirname, '..', '__fixtures__');
@@ -35,7 +34,7 @@ async function main() {
   await loadModule();
 
   const opts: TransformSqlOptions = {
-    prePasses: [transformVerifyCalls, transformJsonStringValues],
+    prePasses: [transformJsonStringValues],
   };
 
   for (const file of fs.readdirSync(INPUT_DIR)) {

--- a/packages/transform/src/index.ts
+++ b/packages/transform/src/index.ts
@@ -108,7 +108,6 @@ export {
   transformSchemaName,
   transformSql,
   transformSqlStatement,
-  transformVerifyCalls,
   validateNoUntransformedSchemas,
   walkPlpgsqlForSchemas,
 } from './transform';

--- a/packages/transform/src/transform.ts
+++ b/packages/transform/src/transform.ts
@@ -1316,46 +1316,6 @@ export function transformComments(
 }
 
 /**
- * Transform verify function calls that use string literals.
- * These are inside SQL strings and not part of the main AST.
- */
-export function transformVerifyCalls(
-  content: string,
-  schemaMapping: Map<string, string>,
-  result: SchemaTransformResult
-): string {
-  const schemas = Array.from(schemaMapping.keys()).sort((a, b) => b.length - a.length);
-  
-  let newContent = content;
-  // The pattern needs the schema name spelled out, case-insensitively.
-  let lowerContent = content.toLowerCase();
-  
-  for (const schema of schemas) {
-    const newName = schemaMapping.get(schema);
-    if (!newName) continue;
-    if (!lowerContent.includes(schema.toLowerCase())) continue;
-    
-    const escapedSchema = cachedEscapeRegexp(schema);
-    
-    const verifyPattern = cachedRegExp(
-      `(verify_(?:function|table|trigger|type|domain|view|index|constraint|schema|policy|table_grant|function_grant|sequence_grant|type_grant)\\s*\\(\\s*')${escapedSchema}(\\.|'\\s*\\))`,
-      'gi'
-    );
-    
-    const before = newContent;
-    newContent = newContent.replace(verifyPattern, `$1${newName}$2`);
-    
-    if (newContent !== before) {
-      lowerContent = newContent.toLowerCase();
-      result.schemasFound.add(schema);
-      result.schemasTransformed.set(schema, newName);
-    }
-  }
-  
-  return newContent;
-}
-
-/**
  * Transform schema names inside JSON/JSONB string values.
  */
 export function transformJsonStringValues(


### PR DESCRIPTION
## Summary

Removes the `transformVerifyCalls` pre-pass (and its export) from `@pgsql/transform`, 18.17.0. It renamed schema names inside verify helper literals by matching a hand-maintained list of helper names:

```
verify_(?:function|table|trigger|type|domain|view|index|constraint|schema|policy|table_grant|...)\s*\(\s*'<schema>(\.|'\s*\))
```

That list is the failure mode it caused: it omits `verify_security`, so that call site silently never got renamed, and every new helper had to be added here and in pgpm's parallel `SCHEMA_NAME_LITERAL_FUNCS`.

Nothing needs it any more. Qualified literals (`'sch.tbl'`) were already reached by the generic `A_Const` pass, and the one case that genuinely required the name list — `verify_schema('sch')`, a bare name with no dot — is now `assert_schema('sch'::regnamespace)`, routed by cast type as of #343. constructive-db regenerates with zero drift without the pre-pass.

Breaking: `transformVerifyCalls` is no longer exported. Callers should drop it from `prePasses`.

The kitchen-sink fixture's `verify_*` block is replaced with the assertion form it verifies (`assert_schema(...::regnamespace)`, `assert_function(...::regprocedure)`, …), and the golden output regenerated with `scripts/make-fixtures.ts`.

## Validation

- `pnpm test` in `packages/transform`: 250 passing, 12 suites
- `pnpm lint`: clean


Link to Devin session: https://app.devin.ai/sessions/37a60838adfb4fd6ac8c29f09c2e2827
Requested by: @pyramation